### PR TITLE
Refactor agent scripts and improve Dockerfiles

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -19,7 +19,7 @@ EXPOSE 8000
 FROM base as production
 ENV NODE_ENV=production
 COPY . .
-RUN npm install --verbose
+RUN npm install --verbose --no-audit
 RUN npm run build
 CMD ["npm", "run", "serve"]
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,7 +23,7 @@ FROM base as production
 ENV NODE_ENV=production
 WORKDIR /server
 COPY . .
-RUN npm install  --verbose
+RUN npm install  --verbose --no-audit
 RUN npm run build
 CMD ["node", "./dist/src/index.js"]
 

--- a/server/src/ansible/_installAgent.yml
+++ b/server/src/ansible/_installAgent.yml
@@ -3,24 +3,87 @@
   become: true
   gather_facts: false
   vars:
-    shell_script: undef
+    base_path: /opt/squirrelserversmanager
 
   tasks:
+    - name: Install agent on targeted device
+      ansible.builtin.debug:
+        msg: Host ID {{ _ssm_deviceId }} with API URL {{ _ssm_masterNodeUrl }}
+
+    - name: Check if NodeJS does exist
+      ansible.builtin.raw: which node
+      check_mode: false
+      changed_when: false
+      failed_when: which_res_node.rc > 1
+      register: which_res_node
+
+    - name: Check if NPM does exist
+      ansible.builtin.raw: which npm
+      check_mode: false
+      changed_when: false
+      failed_when: which_res_npm.rc > 1
+      register: which_res_npm
+
+    - name: Install "PM2" node.js package globally.
+      community.general.npm:
+        name: pm2
+        global: true
+        state: latest
+
+    - name: Install PM2 LogRotate
+      command: pm2 install pm2-logrotate
+
     - name: Check out agent
       ansible.builtin.git:
         force: true
         repo: 'https://github.com/SquirrelCorporation/SquirrelServersManager-Agent.git'
-        dest: /opt/squirrelserversmanager
+        dest: "{{ base_path }}"
       timeout: 600
 
-    - name: Run Shell Script
-      ansible.builtin.shell: "sudo /opt/squirrelserversmanager/install.sh -a -u {{ _ssm_masterNodeUrl }} -s {{ _ssm_deviceId }}"
-      register: shell_output
-      tags:
-        - skip_ansible_lint  # provided variable could require shell modele
-      timeout: 600
+    - name: Stop PM2 Agent if running
+      command: pm2 stop agent
+      ignore_errors: yes
 
-    - name: Print script output
-      ansible.builtin.debug:
-        var: shell_output.stdout_lines
-      timeout: 600
+    - name: Delete PM2 Agent if present
+      command: pm2 delete agent
+      ignore_errors: yes
+
+    - name: Clean directory
+      command:
+        chdir: "{{ base_path }}"
+        cmd: rm -f ssm-agent && rm -f agent.blob && rm -rf ./build && rm -f ./hostid.txt
+
+    - name: Write Node Url in .env file
+      copy:
+        content: "API_URL_MASTER={{ _ssm_masterNodeUrl }}"
+        dest: "{{ base_path }}/.env"
+
+    - name: Write HostId in hostid.txt file
+      copy:
+        content: "{{ _ssm_deviceId }}"
+        dest: "{{ base_path }}/hostid.txt"
+
+    - name: NPM install
+      command:
+        chdir: "{{ base_path }}"
+        cmd: npm install
+
+    - name: NPM run build
+      command:
+        chdir: "{{ base_path }}"
+        cmd: npm run build
+
+    - name: Start PM2 Agent
+      command:
+        chdir: "{{ base_path }}"
+        cmd: pm2 start -f "./build/agent.js"
+
+    - name: Install PM2 on startup
+      command: pm2 startup
+
+    - name: Save Agent on startup
+      command: pm2 save
+
+    - name: Save Agent on startup
+      command: pm2 update
+

--- a/server/src/ansible/_reinstallAgent.yml
+++ b/server/src/ansible/_reinstallAgent.yml
@@ -1,27 +1,89 @@
-- name: Reinstall agent on targeted device
+- name: Re install agent on targeted device
   hosts: all
   become: true
   gather_facts: false
   vars:
-    shell_script: undef
+    base_path: /opt/squirrelserversmanager
 
   tasks:
+    - name: Install agent on targeted device
+      ansible.builtin.debug:
+        msg: Host ID {{ _ssm_deviceId }} with API URL {{ _ssm_masterNodeUrl }}
+
+    - name: Check if NodeJS does exist
+      ansible.builtin.raw: which node
+      check_mode: false
+      changed_when: false
+      failed_when: which_res_node.rc > 1
+      register: which_res_node
+
+    - name: Check if NPM does exist
+      ansible.builtin.raw: which npm
+      check_mode: false
+      changed_when: false
+      failed_when: which_res_npm.rc > 1
+      register: which_res_npm
+
+    - name: Install "PM2" node.js package globally.
+      community.general.npm:
+        name: pm2
+        global: true
+        state: latest
+
+    - name: Install PM2 LogRotate
+      command: pm2 install pm2-logrotate
+
     - name: Check out agent
       ansible.builtin.git:
         force: true
         repo: 'https://github.com/SquirrelCorporation/SquirrelServersManager-Agent.git'
-        dest: /opt/squirrelserversmanager
+        dest: "{{ base_path }}"
       timeout: 600
 
-    - name: Run Shell Script
-      ansible.builtin.shell: "sudo /opt/squirrelserversmanager/install.sh -a -u {{ _ssm_masterNodeUrl }} -s {{ _ssm_deviceId }}"
-      register: shell_output
-      tags:
-        - skip_ansible_lint  # provided variable could require shell modele
-      timeout: 600
+    - name: Stop PM2 Agent if running
+      command: pm2 stop agent
+      ignore_errors: yes
 
-    - name: Print script output
-      ansible.builtin.debug:
-        var: shell_output.stdout_lines
-      timeout: 600
+    - name: Delete PM2 Agent if present
+      command: pm2 delete agent
+      ignore_errors: yes
+
+    - name: Clean directory
+      command:
+        chdir: "{{ base_path }}"
+        cmd: rm -f ssm-agent && rm -f agent.blob && rm -rf ./build && rm -f ./hostid.txt
+
+    - name: Write Node Url in .env file
+      copy:
+        content: "API_URL_MASTER={{ _ssm_masterNodeUrl }}"
+        dest: "{{ base_path }}/.env"
+
+    - name: Write HostId in hostid.txt file
+      copy:
+        content: "{{ _ssm_deviceId }}"
+        dest: "{{ base_path }}/hostid.txt"
+
+    - name: NPM install
+      command:
+        chdir: "{{ base_path }}"
+        cmd: npm install
+
+    - name: NPM run build
+      command:
+        chdir: "{{ base_path }}"
+        cmd: npm run build
+
+    - name: Start PM2 Agent
+      command:
+        chdir: "{{ base_path }}"
+        cmd: pm2 start -f "./build/agent.js"
+
+    - name: Install PM2 on startup
+      command: pm2 startup
+
+    - name: Save Agent on startup
+      command: pm2 save
+
+    - name: Save Agent on startup
+      command: pm2 update
 

--- a/server/src/ansible/_restartAgent.yml
+++ b/server/src/ansible/_restartAgent.yml
@@ -3,17 +3,27 @@
   become: true
   gather_facts: false
   vars:
-    shell_script: undef
+    base_path: /opt/squirrelserversmanager
 
   tasks:
-    - name: Run Shell Script
-      ansible.builtin.shell: "sudo /opt/squirrelserversmanager/restart.sh"
-      register: shell_output
-      tags:
-        - skip_ansible_lint  # provided variable could require shell modele
-      timeout: 600
+    - name: Stop PM2 Agent if running
+      command: pm2 stop agent
+      ignore_errors: yes
 
-    - name: Print script output
-      ansible.builtin.debug:
-        var: shell_output.stdout_lines
-      timeout: 600
+    - name: Delete PM2 Agent if present
+      command: pm2 delete agent
+      ignore_errors: yes
+
+    - name: Start PM2 Agent
+      command:
+        chdir: "{{ base_path }}"
+        cmd: pm2 start -f "./build/agent.js"
+
+    - name: Install PM2 on startup
+      command: pm2 startup
+
+    - name: Save Agent on startup
+      command: pm2 save
+
+    - name: Save Agent on startup
+      command: pm2 update

--- a/server/src/ansible/_uninstallAgent.yml
+++ b/server/src/ansible/_uninstallAgent.yml
@@ -6,17 +6,13 @@
     shell_script: undef
 
   tasks:
-    - name: Run Shell Script
-      ansible.builtin.shell: "sudo /opt/squirrelserversmanager/uninstall.sh"
-      register: shell_output
-      tags:
-        - skip_ansible_lint  # provided variable could require shell modele
-      timeout: 600
+    - name: Stop PM2 Agent if running
+      command: pm2 stop agent
+      ignore_errors: yes
 
-    - name: Print script output
-      ansible.builtin.debug:
-        var: shell_output.stdout_lines
-      timeout: 600
+    - name: Delete PM2 Agent if present
+      command: pm2 delete agent
+      ignore_errors: yes
 
     - name: Recursively remove directory
       ansible.builtin.file:

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -8,6 +8,9 @@ yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
 
+# dependencies
+/package-lock.json
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 


### PR DESCRIPTION
Optimised agent scripts concerning install, uninstall, reinstall, and restart processes by using PM2 for agent management instead of shell scripts. Updated Dockerfiles for both client and server to install node packages with '--no-audit' flag. Additionally, '.gitignore' file has been updated to ignore 'package-lock.json'.