### PR TITLE
Refactor import statements for SsmAnsible and SettingsKeys

### DIFF
--- a/server/src/core/startup/index.ts
+++ b/server/src/core/startup/index.ts
@@ -1,4 +1,4 @@
-import { DefaultValue, GeneralSettingsKeys } from 'ssm-shared-lib/distribution/enums/settings';
+import { SettingsKeys } from 'ssm-shared-lib';
 import { getFromCache } from '../../data/cache';
 import initRedisValues from '../../data/cache/defaults';
 import providerConf from '../../integrations/docker/registries/providers/provider.conf';
@@ -10,16 +10,16 @@ import { setAnsibleVersion } from '../system/version';
 
 async function needConfigurationInit() {
   logger.info(`[CONFIGURATION] - needInit`);
-  await DeviceAuthUseCases.saveAllDeviceAuthSshKeys();
+  void DeviceAuthUseCases.saveAllDeviceAuthSshKeys();
 
-  const version = await getFromCache(GeneralSettingsKeys.SCHEME_VERSION);
+  const version = await getFromCache(SettingsKeys.GeneralSettingsKeys.SCHEME_VERSION);
 
   logger.info(`[CONFIGURATION] - needInit - Scheme Version: ${version}`);
 
-  if (version !== DefaultValue.SCHEME_VERSION) {
+  if (version !== SettingsKeys.DefaultValue.SCHEME_VERSION) {
     await initRedisValues();
     await PlaybookUseCases.initPlaybook();
-    await setAnsibleVersion();
+    void setAnsibleVersion();
 
     providerConf
       .filter(({ persist }) => persist)

--- a/server/src/integrations/shell/index.ts
+++ b/server/src/integrations/shell/index.ts
@@ -5,7 +5,6 @@ import User from '../../data/database/model/User';
 import AnsibleTaskRepo from '../../data/database/repository/AnsibleTaskRepo';
 import DeviceAuthRepo from '../../data/database/repository/DeviceAuthRepo';
 import logger from '../../logger';
-import { DEFAULT_VAULT_ID, vaultEncrypt } from '../ansible-vault/vault';
 import Inventory from '../ansible/utils/InventoryTransformer';
 import { Ansible } from '../../types/typings';
 import ansibleCmd from '../ansible/AnsibleCmd';

--- a/server/src/tests/integrations/ansible/InventoryTransformer.test.ts
+++ b/server/src/tests/integrations/ansible/InventoryTransformer.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from 'vitest';
-import { SSHType } from 'ssm-shared-lib/distribution/enums/ansible';
+import { SsmAnsible } from 'ssm-shared-lib';
 import InventoryTransformer from '../../../integrations/ansible/utils/InventoryTransformer'; // replace with actual file path
 
 describe('test InventoryTransformer', () => {
   test('inventoryBuilder', () => {
     const deviceAuth = {
       device: { uuid: '1234-5678-9101', ip: '192.168.1.1' },
-      authType: SSHType.UserPassword,
+      authType: SsmAnsible.SSHType.UserPassword,
       becomeMethod: 'sudo',
       becomePass: 'password',
       sshUser: 'root',
@@ -44,7 +44,7 @@ describe('test InventoryTransformer', () => {
   test('inventoryBuilderForTarget', () => {
     const deviceAuth = {
       device: { uuid: '1234-5678-9102', ip: '192.168.1.2' },
-      authType: SSHType.UserPassword,
+      authType: SsmAnsible.SSHType.UserPassword,
       becomeMethod: 'sudo',
       becomePass: 'qwerty',
       sshUser: 'admin',
@@ -72,7 +72,7 @@ describe('test InventoryTransformer', () => {
   test('inventoryBuilderForTargetWithSshKey', () => {
     const deviceAuth = {
       device: { uuid: '1234-5678-9102', ip: '192.168.1.2' },
-      authType: SSHType.KeyBased,
+      authType: SsmAnsible.SSHType.KeyBased,
       becomeMethod: 'sudo',
       becomePass: 'qwerty',
       sshUser: 'admin',
@@ -107,7 +107,7 @@ describe('test InventoryTransformer', () => {
   test('inventoryBuilderForTargetWithSshKeyAndKeyPhrase', () => {
     const deviceAuth = {
       device: { uuid: '1234-5678-9102', ip: '192.168.1.2' },
-      authType: SSHType.KeyBased,
+      authType: SsmAnsible.SSHType.KeyBased,
       becomeMethod: 'sudo',
       becomePass: 'qwerty',
       sshUser: 'admin',
@@ -154,7 +154,7 @@ describe('test InventoryTransformer', () => {
   test('inventoryBuilder for deviceAuth with strict host key checking', () => {
     const deviceAuth = {
       device: { uuid: '1234-5678-9103', ip: '192.168.1.3' },
-      authType: SSHType.UserPassword,
+      authType: SsmAnsible.SSHType.UserPassword,
       strictHostKeyChecking: true,
       becomeMethod: 'su',
       becomePass: 'adminpassword',
@@ -189,7 +189,10 @@ describe('test InventoryTransformer', () => {
   });
 
   test('inventoryBuilderForTarget for deviceAuth with undefined IP', () => {
-    const deviceAuth = { device: { uuid: '1234-5678-9104' }, authType: SSHType.UserPassword };
+    const deviceAuth = {
+      device: { uuid: '1234-5678-9104' },
+      authType: SsmAnsible.SSHType.UserPassword,
+    };
     // @ts-expect-error partial type
     const result = InventoryTransformer.inventoryBuilderForTarget([deviceAuth]);
     const expectedResult = {
@@ -213,7 +216,7 @@ describe('test InventoryTransformer', () => {
   test('inventoryBuilderForTarget with multiple devicesAuth', () => {
     const deviceAuth1 = {
       device: { uuid: '1234-5678-9105', ip: '192.168.1.4' },
-      authType: SSHType.UserPassword,
+      authType: SsmAnsible.SSHType.UserPassword,
       becomeMethod: 'sudo',
       becomePass: 'password1',
       sshUser: 'root',
@@ -221,7 +224,7 @@ describe('test InventoryTransformer', () => {
 
     const deviceAuth2 = {
       device: { uuid: '2234-5678-9106', ip: '192.168.1.5' },
-      authType: SSHType.UserPassword,
+      authType: SsmAnsible.SSHType.UserPassword,
       becomeMethod: 'sudo',
       becomePass: 'password2',
       sshUser: 'root',


### PR DESCRIPTION
The change primarily involves refining the import statements to streamline the code base. The refactor includes importing SettingsKeys in the startup module and SsmAnsible across multiple modules and changing the encryption logic method in DockerAPIHelper.test. Other changes include minor tweaks in the async/await functions and the removal of an unused import in the shell module.