### PR TITLE
Update package dependencies

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "ssm-shared-lib": "file:../shared-lib/",
-    "antd": "^5.18.1",
+    "antd": "^5.18.2",
     "@ant-design/icons": "^5.3.7",
     "@ant-design/pro-components": "^2.7.10",
     "@ant-design/use-emotion-css": "1.0.4",
@@ -96,7 +96,7 @@
     "@umijs/fabric": "^4.0.1",
     "@umijs/lint": "^4.2.11",
     "cross-env": "^7.0.3",
-    "eslint": "^9.4.0",
+    "eslint": "^9.5.0",
     "express": "^4.19.2",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/server/package.json
+++ b/server/package.json
@@ -26,7 +26,7 @@
     "joi": "^17.13.1",
     "jsonwebtoken": "^9.0.2",
     "luxon": "^3.4.4",
-    "mongoose": "^8.4.1",
+    "mongoose": "^8.4.3",
     "node-cron": "^3.0.3",
     "node-ssh": "^13.2.0",
     "parse-docker-image-name": "^3.0.0",
@@ -44,7 +44,7 @@
     "semver": "^7.6.2",
     "shelljs": "^0.8.5",
     "ssm-shared-lib": "file:../shared-lib/",
-    "@aws-sdk/client-ecr": "^3.596.0"
+    "@aws-sdk/client-ecr": "^3.598.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
@@ -64,7 +64,7 @@
     "@types/shelljs": "^0.8.15",
     "@types/uuid": "^9.0.8",
     "@vitest/coverage-v8": "^1.6.0",
-    "eslint": "^9.4.0",
+    "eslint": "^9.5.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "node-mocks-http": "^1.14.1",


### PR DESCRIPTION
The package dependencies for both the server and client side have been updated. The libraries "mongoose", "@aws-sdk/client-ecr", and "eslint" for the server, and "antd" and "eslint" for the client, have been updated to newer versions. These updates contain bug fixes and improvements which help keep our application secure and efficient.