### PR TITLE
BUGFIX - Fix deletion following refacto

### DIFF
--- a/server/src/integrations/playbooks-repository/PlaybooksRepositoryComponent.ts
+++ b/server/src/integrations/playbooks-repository/PlaybooksRepositoryComponent.ts
@@ -148,7 +148,9 @@ abstract class PlaybooksRepositoryComponent {
   }
 
   public fileBelongToRepository(path: string) {
-    logger.info(`rootPath: ${this.directory?.split('/')[0]} versus ${path.split('/')[0]}`);
+    this.childLogger.info(
+      `rootPath: ${this.directory?.split('/')[0]} versus ${path.split('/')[0]}`,
+    );
     return this.directory?.split('/')[0] === path.split('/')[0];
   }
 

--- a/server/src/tests/integrations/playbooks-repository/PlaybookRepositoryComponent.test.ts
+++ b/server/src/tests/integrations/playbooks-repository/PlaybookRepositoryComponent.test.ts
@@ -6,7 +6,11 @@ describe('PlaybooksRepositoryComponent', () => {
   let playbooksRepositoryComponent: PlaybooksRepositoryComponent;
 
   beforeEach(() => {
-    const logger = { child: vi.fn() };
+    const logger = {
+      child: () => {
+        return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      },
+    };
     playbooksRepositoryComponent = new LocalRepositoryComponent('uuid', logger, 'name', 'path');
   });
 

--- a/server/src/use-cases/PlaybooksRepositoryUseCases.ts
+++ b/server/src/use-cases/PlaybooksRepositoryUseCases.ts
@@ -109,7 +109,7 @@ async function deleteAnyInPlaybooksRepository(
   if (!playbooksRepositoryComponent.fileBelongToRepository(fullPath)) {
     throw new ForbiddenError('The selected path doesnt seems to belong to the repository');
   }
-  Shell.FileSystemManager.createDirectory(fullPath, playbooksRepositoryComponent.rootPath);
+  Shell.FileSystemManager.deleteFiles(fullPath, playbooksRepositoryComponent.rootPath);
   await playbooksRepositoryComponent.syncToDatabase();
 }
 


### PR DESCRIPTION
The code modifications focus on two key changes: refactoring the logging in the PlaybooksRepositoryComponent and amending the filesystem operation in PlaybooksRepositoryUseCases. The logger method now wraps the logging statement in a more efficient method call, and a directory creation operation has been replaced with a file deletion operation.