### PR TITLE
[FEAT] Add default local repository for playbooks on user creation

### DIFF
--- a/server/src/data/database/model/Playbook.ts
+++ b/server/src/data/database/model/Playbook.ts
@@ -31,6 +31,7 @@ const schema = new Schema<Playbook>(
     uniqueQuickRef: {
       type: Schema.Types.String,
       unique: true,
+      sparse: true,
     },
     path: {
       type: Schema.Types.String,

--- a/server/src/data/database/repository/UserRepo.ts
+++ b/server/src/data/database/repository/UserRepo.ts
@@ -42,6 +42,10 @@ async function updateLogsLevel(email: string, userLogsLevel: UserLogsLevel): Pro
   await UsersModel.updateOne({ email: email }, { logsLevel: userLogsLevel }).exec();
 }
 
+async function findFirst(): Promise<User | null> {
+  return await UsersModel.findOne().lean().exec();
+}
+
 export default {
   create,
   findByEmailAndPassword,
@@ -50,4 +54,5 @@ export default {
   resetApiKey,
   updateLogsLevel,
   findByApiKey,
+  findFirst,
 };

--- a/server/src/services/user/user.ts
+++ b/server/src/services/user/user.ts
@@ -1,6 +1,7 @@
 import { SettingsKeys } from 'ssm-shared-lib';
 import { AuthFailureError } from '../../core/api/ApiError';
 import { SuccessResponse } from '../../core/api/ApiResponse';
+import { createADefaultLocalUserRepository } from '../../core/startup';
 import { getAnsibleVersion } from '../../core/system/version';
 import { Role } from '../../data/database/model/User';
 import UserRepo from '../../data/database/repository/UserRepo';
@@ -99,7 +100,7 @@ export const createFirstUser = asyncHandler(async (req, res) => {
   if (hasUser) {
     throw new AuthFailureError('Your instance already has a user, you must first connect');
   }
-
+  // TODO: move to use cases
   await UserRepo.create({
     email: email,
     password: password,
@@ -107,6 +108,7 @@ export const createFirstUser = asyncHandler(async (req, res) => {
     role: Role.ADMIN,
     avatar: avatar || '/avatars/squirrel.svg',
   });
+  await createADefaultLocalUserRepository();
   new SuccessResponse('Create first user').send(res);
 });
 

--- a/shared-lib/src/enums/settings.ts
+++ b/shared-lib/src/enums/settings.ts
@@ -15,7 +15,7 @@ export enum AnsibleReservedExtraVarsKeys {
 }
 
 export enum DefaultValue {
-  SCHEME_VERSION = '6',
+  SCHEME_VERSION = '7',
   SERVER_LOG_RETENTION_IN_DAYS = '30',
   CONSIDER_DEVICE_OFFLINE_AFTER_IN_MINUTES = '3',
   CONSIDER_PERFORMANCE_GOOD_MEM_IF_GREATER = '10',


### PR DESCRIPTION
Added an automatic default local user repository for playbooks when a new user is created. This was done by modifying startup logic to include a default user creation function, and updating the UserRepo to support this change. The SCHEME_VERSION in settings has also been updated to reflect the change.