### PR TITLE
[FIX] Fix incorrect argument order in editPlaybook function

### DIFF
--- a/server/src/integrations/shell/ShellWrapper.ts
+++ b/server/src/integrations/shell/ShellWrapper.ts
@@ -8,7 +8,7 @@ const ShellWrapper = {
   touch: shell.touch.bind(shell),
   test: shell.test.bind(shell),
   chmod: shell.chmod.bind(shell),
-  to: (str: string, path: string) => shell.ShellString(str).to(path),
+  to: (content: string, path: string) => shell.ShellString(content).to(path),
 };
 
 export default ShellWrapper;

--- a/server/src/services/playbooks/playbook.ts
+++ b/server/src/services/playbooks/playbook.ts
@@ -39,7 +39,7 @@ export const editPlaybook = asyncHandler(async (req, res) => {
     throw new NotFoundError(`Playbook ${uuid} not found`);
   }
   try {
-    Shell.PlaybookFileManager.editPlaybook(playbook.path, req.body.content);
+    Shell.PlaybookFileManager.editPlaybook(req.body.content, playbook.path);
     new SuccessResponse('Edit playbook successful').send(res);
   } catch (error: any) {
     throw new InternalError(error.message);


### PR DESCRIPTION
The order of the arguments in the 'editPlaybook' function was switched to ensure proper functionality. The change was also reflected in the shell file 'ShellWrapper.ts' to maintain consistency across the application. The argument that was formerly named 'str' has been renamed to 'content' for better code readability.