### PR TITLE
[BUG] Update Carousel lazyLoad setting to progressive

### DIFF
--- a/client/src/pages/Devices/index.tsx
+++ b/client/src/pages/Devices/index.tsx
@@ -110,7 +110,7 @@ const Index = memo(() => {
           <Carousel
             style={{ width: 300, height: 70, zIndex: 1000 }}
             dotPosition={'right'}
-            lazyLoad={'ondemand'}
+            lazyLoad={'progressive'}
           >
             <div style={{ width: 300, height: 70, zIndex: 1000 }}>
               <div


### PR DESCRIPTION
The lazyLoad setting for the Carousel component in the Devices page has been updated to 'progressive' from 'ondemand'. This change is intended to improve the loading behavior of the Carousel for a smoother user experience.