### PR TITLE
Update ansible URL and refine UI messages

### DIFF
--- a/client/src/components/DeviceConfiguration/CheckDeviceConnection.tsx
+++ b/client/src/components/DeviceConfiguration/CheckDeviceConnection.tsx
@@ -94,7 +94,7 @@ const CheckDeviceConnection: React.FC<CheckDeviceConnectionProps> = (props) => {
       direction="vertical"
       items={[
         {
-          title: 'Ansible Playbook test',
+          title: 'Ansible Playbook : Ansible Ping & Call SSM API URL',
           description: (
             <>
               {playbookStatus}{' '}

--- a/client/src/components/TerminalModal/TerminalLogs.tsx
+++ b/client/src/components/TerminalModal/TerminalLogs.tsx
@@ -13,17 +13,17 @@ const TerminalLogs: React.FC<TerminalLogsProps> = (props) => {
     <>
       {previous}
       <span style={terminalContentStyle}>
-        {execLog.stdout?.split('\n').map((e, index, array) => {
+        {execLog.stdout?.split('\n')?.map((e, index, array) => {
           return (
             <>
-              {e.split('\\r\\n').map((f) => {
+              {e.split('\\r\\n')?.map((f) => {
                 braces +=
                   (f.match(/\{/g)?.length || [].length) -
                   (f.match(/}/g)?.length || [].length);
                 return (
                   <>
                     {/* Small trick to render &nbsp; for json object */}
-                    {'\u00A0'.repeat(braces)}
+                    {'\u00A0'.repeat(braces < 0 ? 0 : braces)}
                     {f}
                   </>
                 );

--- a/server/src/ansible/inventory/inventory.py
+++ b/server/src/ansible/inventory/inventory.py
@@ -48,8 +48,8 @@ def parse_args():
 
 
 def load_inventory():
-    headers = {'Accept': 'application/json', 'Authorization': "Bearer {}".format(os.getenv("SSM_API_KEY")}
-    r = requests.get('http://localhost:3000/ansible/inventory', headers=headers)
+    headers = {'Accept': 'application/json', 'Authorization': "Bearer {}".format(os.getenv("SSM_API_KEY"))}
+    r = requests.get('http://localhost:3000/playbooks/inventory', headers=headers)
     return r.json()['data']
 
 


### PR DESCRIPTION
Changed the ansible inventory URL from '/ansible/inventory' to '/playbooks/inventory' for improved coherence with the path structure. Updated certain user interface messages to provide clearer instructions and function description. Also, modified terminal log processing to ensure indentation level doesn't go negative for better log readability.