### PR TITLE
Add feature to delete and resync playbooks

### DIFF
--- a/client/src/components/Template/Title.tsx
+++ b/client/src/components/Template/Title.tsx
@@ -20,6 +20,7 @@ export enum SettingsSubTitleColors {
   SERVER = '#8e7d50',
   GIT = '#336048',
   LOCAL = '#4b4a4a',
+  DEBUG = '#b614b6',
 }
 
 export type PageContainerTitleProps = {

--- a/client/src/pages/Admin/Settings/components/AdvancedSettings.tsx
+++ b/client/src/pages/Admin/Settings/components/AdvancedSettings.tsx
@@ -8,14 +8,11 @@ import {
   deleteAnsibleLogs,
   deleteContainerStats,
   deleteDeviceStats,
+  deletePlaybooksAndResync,
   deleteServerLogs,
   postRestartServer,
 } from '@/services/rest/settings';
-import {
-  InfoCircleFilled,
-  RedoOutlined,
-  TableOutlined,
-} from '@ant-design/icons';
+import { BugFilled, InfoCircleFilled, RedoOutlined } from '@ant-design/icons';
 import { Button, Card, Flex, Popover, Space, Typography } from 'antd';
 import { DeleteOutline } from 'antd-mobile-icons';
 import React from 'react';
@@ -158,6 +155,37 @@ const AdvancedSettings: React.FC = () => {
               Restart
             </Button>
             <Space.Compact style={{ width: 'auto' }} />
+          </Space>
+        </Flex>
+      </Card>
+      <Card
+        type="inner"
+        style={{ marginTop: 16 }}
+        title={
+          <Title.SubTitle
+            title={'Debug'}
+            backgroundColor={SettingsSubTitleColors.DEBUG}
+            icon={<BugFilled />}
+          />
+        }
+      >
+        <Flex vertical gap={32} style={{ width: '50%' }}>
+          <Space direction="horizontal" size="middle">
+            <Typography>
+              {' '}
+              <Popover content={'Delete all playbooks and resync'}>
+                <InfoCircleFilled />
+              </Popover>{' '}
+              Playbooks
+            </Typography>{' '}
+            <Button
+              danger
+              icon={<DeleteOutline />}
+              onClick={async () => await deletePlaybooksAndResync()}
+            >
+              Purge & Sync again
+            </Button>
+            <Space.Compact style={{ width: '100%' }} />
           </Space>
         </Flex>
       </Card>

--- a/client/src/services/rest/settings.ts
+++ b/client/src/services/rest/settings.ts
@@ -88,6 +88,17 @@ export async function deleteDeviceStats(options?: Record<string, any>) {
   });
 }
 
+export async function deletePlaybooksAndResync(options?: Record<string, any>) {
+  return request<API.SimpleResult>(
+    `/api/settings/advanced/playbooks-and-resync`,
+    {
+      method: 'DELETE',
+      ...{},
+      ...(options || {}),
+    },
+  );
+}
+
 export async function postContainerStatsSettings(
   type: string,
   value: number,

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -15,6 +15,7 @@ import {
   deleteContainerStats,
   deleteDeviceStats,
   deleteLogs,
+  deletePlaybooksModelAndResync,
   postRestartServer,
 } from '../services/settings/advanced';
 
@@ -36,5 +37,5 @@ router.delete('/advanced/logs', deleteLogs);
 router.delete('/advanced/ansible-logs', deleteAnsibleLogs);
 router.delete('/advanced/device-stats', deleteDeviceStats);
 router.delete('/advanced/container-stats', deleteContainerStats);
-
+router.delete('/advanced/playbooks-and-resync', deletePlaybooksModelAndResync);
 export default router;

--- a/server/src/services/settings/advanced.ts
+++ b/server/src/services/settings/advanced.ts
@@ -1,7 +1,8 @@
-import { Promise } from 'mongoose';
-import { res } from 'pino-std-serializers';
 import { SuccessResponse } from '../../core/api/ApiResponse';
-import { PlaybookModel } from '../../data/database/model/Playbook';
+import {
+  COLLECTION_NAME as PlaybookCollectionName,
+  PlaybookModel,
+} from '../../data/database/model/Playbook';
 import AnsibleLogsRepo from '../../data/database/repository/AnsibleLogsRepo';
 import ContainerStatsRepo from '../../data/database/repository/ContainerStatsRepo';
 import DeviceStatRepo from '../../data/database/repository/DeviceStatRepo';
@@ -35,7 +36,7 @@ export const deleteDeviceStats = asyncHandler(async (req, res) => {
 });
 
 export const deletePlaybooksModelAndResync = asyncHandler(async (req, res) => {
-  await PlaybookModel.db.collection('playbooks').drop();
+  await PlaybookModel.db.collection(PlaybookCollectionName).drop();
   await PlaybooksRepositoryEngine.registerRepositories();
   await PlaybooksRepositoryEngine.syncAllRegistered();
   new SuccessResponse('All data purged successfully').send(res);

--- a/server/src/services/settings/advanced.ts
+++ b/server/src/services/settings/advanced.ts
@@ -1,10 +1,14 @@
+import { Promise } from 'mongoose';
+import { res } from 'pino-std-serializers';
 import { SuccessResponse } from '../../core/api/ApiResponse';
+import { PlaybookModel } from '../../data/database/model/Playbook';
 import AnsibleLogsRepo from '../../data/database/repository/AnsibleLogsRepo';
 import ContainerStatsRepo from '../../data/database/repository/ContainerStatsRepo';
 import DeviceStatRepo from '../../data/database/repository/DeviceStatRepo';
 import LogsRepo from '../../data/database/repository/LogsRepo';
 import asyncHandler from '../../helpers/AsyncHandler';
 import { restart } from '../../index';
+import PlaybooksRepositoryEngine from '../../integrations/playbooks-repository/PlaybooksRepositoryEngine';
 
 export const postRestartServer = asyncHandler(async (req, res) => {
   await restart();
@@ -28,4 +32,11 @@ export const deleteContainerStats = asyncHandler(async (req, res) => {
 export const deleteDeviceStats = asyncHandler(async (req, res) => {
   await DeviceStatRepo.deleteAll();
   new SuccessResponse('Device stats Purged Successfully').send(res);
+});
+
+export const deletePlaybooksModelAndResync = asyncHandler(async (req, res) => {
+  await PlaybookModel.db.collection('playbooks').drop();
+  await PlaybooksRepositoryEngine.registerRepositories();
+  await PlaybooksRepositoryEngine.syncAllRegistered();
+  new SuccessResponse('All data purged successfully').send(res);
 });


### PR DESCRIPTION
A new feature called "deletePlaybooksModelAndResync" has been added to the advanced settings. This allows users to delete all playbooks and then resync again. Modifications were made to server routing, client services, and the Advanced Settings UI component to accommodate this change.