### PR TITLE
[FEAT] Add ability to show containers for specific device

### DIFF
--- a/client/src/pages/Devices/ContainerMetas.tsx
+++ b/client/src/pages/Devices/ContainerMetas.tsx
@@ -1,0 +1,161 @@
+import ServiceQuickActionDropDown from '@/components/ServiceComponents/ServiceQuickAction/ServiceQuickActionDropDown';
+import ServiceQuickActionReference, {
+  ServiceQuickActionReferenceActions,
+  ServiceQuickActionReferenceTypes,
+} from '@/components/ServiceComponents/ServiceQuickAction/ServiceQuickActionReference';
+import ContainerAvatar from '@/pages/Services/components/ContainerAvatar';
+import ContainerStatProgress from '@/pages/Services/components/ContainerStatProgress';
+import InfoToolTipCard from '@/pages/Services/components/InfoToolTipCard';
+import StatusTag from '@/pages/Services/components/StatusTag';
+import UpdateAvailableTag from '@/pages/Services/components/UpdateAvailableTag';
+import { postContainerAction } from '@/services/rest/containers';
+import { InfoCircleOutlined } from '@ant-design/icons';
+import { ProFieldValueType, ProListMetas } from '@ant-design/pro-components';
+import { Flex, message, Popover, Tag, Tooltip } from 'antd';
+import React from 'react';
+import { API, SsmContainer } from 'ssm-shared-lib';
+
+type ContainerMetasProps = {
+  selectedRecord?: API.Container;
+  setSelectedRecord: React.Dispatch<
+    React.SetStateAction<API.Container | undefined>
+  >;
+  setIsEditContainerCustomNameModalOpened: React.Dispatch<
+    React.SetStateAction<boolean>
+  >;
+};
+const ContainerMetas = (props: ContainerMetasProps) => {
+  const handleQuickAction = async (idx: number) => {
+    if (
+      ServiceQuickActionReference[idx].type ===
+      ServiceQuickActionReferenceTypes.ACTION
+    ) {
+      if (
+        ServiceQuickActionReference[idx].action ===
+        ServiceQuickActionReferenceActions.RENAME
+      ) {
+        props.setIsEditContainerCustomNameModalOpened(true);
+      }
+      if (
+        Object.values(SsmContainer.Actions).includes(
+          ServiceQuickActionReference[idx].action as SsmContainer.Actions,
+        )
+      ) {
+        await postContainerAction(
+          props.selectedRecord?.id as string,
+          ServiceQuickActionReference[idx].action as SsmContainer.Actions,
+        ).then(() => {
+          message.info({
+            content: `Container : ${ServiceQuickActionReference[idx].action}`,
+          });
+        });
+      }
+    }
+  };
+
+  return {
+    title: {
+      search: true,
+      title: 'Name',
+      dataIndex: 'name',
+      render: (_, row) => {
+        return row.customName || row.name;
+      },
+    },
+    subTitle: {
+      search: false,
+      render: (_, row) => {
+        return (
+          <>
+            <StatusTag status={row.status} />
+            <UpdateAvailableTag updateAvailable={row.updateAvailable} />
+          </>
+        );
+      },
+    },
+    updateAvailable: {
+      dataIndex: 'updateAvailable',
+      title: 'Update Available',
+      valueType: 'switch' as ProFieldValueType,
+    },
+    status: {
+      dataIndex: 'status',
+      title: 'Status',
+      valueType: 'select' as ProFieldValueType,
+      valueEnum: {
+        running: {
+          text: 'running',
+        },
+        paused: {
+          text: 'paused',
+        },
+      },
+    },
+    avatar: {
+      search: false,
+      render: (_, row) => {
+        return <ContainerAvatar row={row} key={row.id} />;
+      },
+    },
+    device: {
+      title: 'Device',
+      search: true,
+      dataIndex: ['device', 'uuid'],
+    },
+    content: {
+      search: false,
+      render: (_, row) => {
+        return (
+          <div
+            style={{
+              flex: 1,
+            }}
+          >
+            <div
+              style={{
+                width: 300,
+              }}
+            >
+              <>
+                On{' '}
+                <Popover content={row.device?.fqdn}>
+                  <Tag color="black">{row.device?.ip}</Tag>
+                </Popover>
+                <Flex gap="middle">
+                  <ContainerStatProgress containerId={row.id} />
+                </Flex>
+              </>
+            </div>
+          </div>
+        );
+      },
+    },
+    actions: {
+      cardActionProps: 'extra',
+      search: false,
+      render: (text, row) => [
+        <Tooltip
+          key={`info-${row.id}`}
+          color={'transparent'}
+          title={<InfoToolTipCard item={row} />}
+        >
+          <InfoCircleOutlined style={{ color: 'rgb(22, 104, 220)' }} />
+        </Tooltip>,
+        <a
+          key={`quickAction-${row.id}`}
+          onClick={() => {
+            props.setSelectedRecord(row);
+          }}
+        >
+          <ServiceQuickActionDropDown onDropDownClicked={handleQuickAction} />
+        </a>,
+      ],
+    },
+    id: {
+      dataIndex: 'id',
+      search: false,
+    },
+  } as ProListMetas<API.Container>;
+};
+
+export default ContainerMetas;

--- a/client/src/pages/Devices/components/ListComponent.tsx
+++ b/client/src/pages/Devices/components/ListComponent.tsx
@@ -1,0 +1,125 @@
+import { DeviceStatType } from '@/components/Charts/DeviceStatType';
+import TinyLineDeviceGraph from '@/components/Charts/TinyLineDeviceGraph';
+import TinyRingProgressDeviceGraph from '@/components/Charts/TinyRingProgressDeviceGraph';
+import TinyRingProgressDeviceIndicator from '@/components/Charts/TinyRingProgressDeviceIndicator';
+import DeviceStatusTag from '@/components/DeviceComponents/DeviceStatusTag';
+import { WhhCpu, WhhRam } from '@/components/Icons/CustomIcons';
+import styles from '@/pages/Devices/Devices.less';
+import DeviceStatus from '@/utils/devicestatus';
+import { Carousel, Col, Row, Typography } from 'antd';
+import React from 'react';
+import { API } from 'ssm-shared-lib';
+
+const { Text } = Typography;
+
+const ListContent: React.FC<API.DeviceItem> = (props: API.DeviceItem) => (
+  <div className={styles.listContent} key={props.uuid}>
+    <div className={styles.listContentItem}>
+      <span>
+        <DeviceStatusTag status={props.status} />
+      </span>
+      <p>{props.hostname}</p>
+    </div>
+    <div className={styles.listContentItem} style={{ width: '80px' }}>
+      {props.status !== DeviceStatus.UNMANAGED && (
+        <>
+          <p style={{ minWidth: '80px' }}>
+            <WhhCpu /> {props.cpuSpeed?.toFixed(1)} Ghz
+          </p>
+          <p style={{ minWidth: '80px' }}>
+            <WhhRam /> {props.mem ? (props.mem / 1024).toFixed(0) : 'NaN'} Gb
+          </p>
+        </>
+      )}
+    </div>
+    <div className={styles.listContentItem}>
+      {(props.status !== DeviceStatus.UNMANAGED && (
+        <Carousel
+          style={{ width: 300, height: 70, zIndex: 1000 }}
+          dotPosition={'right'}
+          lazyLoad={'progressive'}
+        >
+          <div style={{ width: 300, height: 70, zIndex: 1000 }}>
+            <div
+              style={{
+                width: 300,
+                height: 70,
+                zIndex: 1000,
+                paddingTop: '15px',
+              }}
+            >
+              <Row style={{ alignItems: 'center' }} justify="center">
+                <Col span={6}>
+                  <TinyRingProgressDeviceGraph
+                    type={DeviceStatType.CPU}
+                    deviceUuid={props.uuid}
+                  />
+                </Col>
+                <Col span={6}>
+                  <TinyRingProgressDeviceGraph
+                    type={DeviceStatType.MEM_USED}
+                    deviceUuid={props.uuid}
+                  />
+                </Col>
+                <Col span={6}>
+                  <TinyRingProgressDeviceIndicator
+                    deviceUuid={props.uuid}
+                    type={DeviceStatType.SERVICES}
+                  />
+                </Col>
+              </Row>
+            </div>
+          </div>
+          <div style={{ width: 300, height: 70, zIndex: 1000 }}>
+            <div style={{ width: 300, height: 70, zIndex: 1000 }}>
+              <Row style={{ alignItems: 'center' }} justify="center">
+                <Col span={24}>
+                  <TinyLineDeviceGraph
+                    type={DeviceStatType.CPU}
+                    deviceUuid={props.uuid}
+                    from={24}
+                  />
+                </Col>
+              </Row>
+              <Row>
+                <Col
+                  span={24}
+                  style={{ marginTop: '-5px', textAlign: 'center' }}
+                >
+                  <Text type="secondary" style={{ fontSize: '8px' }}>
+                    CPU
+                  </Text>
+                </Col>
+              </Row>
+            </div>
+          </div>
+          <div style={{ width: 300, height: 70, zIndex: 1000 }}>
+            <div style={{ width: 300, height: 70, zIndex: 1000 }}>
+              <Row style={{ alignItems: 'center' }} justify="center">
+                <Col span={24}>
+                  <TinyLineDeviceGraph
+                    type={DeviceStatType.MEM_USED}
+                    deviceUuid={props.uuid}
+                    from={24}
+                  />
+                </Col>
+              </Row>
+              <Row>
+                <Col
+                  span={24}
+                  style={{ marginTop: '-5px', textAlign: 'center' }}
+                >
+                  <Text type="secondary" style={{ fontSize: '8px' }}>
+                    MEM USED
+                  </Text>
+                </Col>
+              </Row>{' '}
+            </div>
+          </div>
+        </Carousel>
+      )) || <div style={{ width: 300, height: 70, zIndex: 1000 }} />}
+    </div>
+  </div>
+);
+
+export default ListContent;

--- a/client/src/pages/Devices/index.tsx
+++ b/client/src/pages/Devices/index.tsx
@@ -1,45 +1,22 @@
-import { DeviceStatType } from '@/components/Charts/DeviceStatType';
-import TinyLineDeviceGraph from '@/components/Charts/TinyLineDeviceGraph';
-import TinyRingProgressDeviceGraph from '@/components/Charts/TinyRingProgressDeviceGraph';
-import TinyRingProgressDeviceIndicator from '@/components/Charts/TinyRingProgressDeviceIndicator';
 import DeviceQuickActionDropDown from '@/components/DeviceComponents/DeviceQuickAction/DeviceQuickActionDropDown';
-import DeviceStatusTag from '@/components/DeviceComponents/DeviceStatusTag';
 import { OsLogo } from '@/components/DeviceComponents/OsLogo/OsLogo';
-import { CarbonBatchJob, WhhCpu, WhhRam } from '@/components/Icons/CustomIcons';
+import { CarbonBatchJob } from '@/components/Icons/CustomIcons';
 import Title, { PageContainerTitleColors } from '@/components/Template/Title';
 import TerminalModal, { TerminalStateProps } from '@/components/TerminalModal';
+import ListContent from '@/pages/Devices/components/ListComponent';
 import { getDevices } from '@/services/rest/device';
-import DeviceStatus from '@/utils/devicestatus';
-import { Link } from '@@/exports';
+import { Link } from '@umijs/max';
 import {
   AppstoreOutlined,
   ControlOutlined,
   TableOutlined,
 } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-components';
-import {
-  Avatar,
-  Button,
-  Card,
-  Carousel,
-  Col,
-  List,
-  Row,
-  Tooltip,
-  Typography,
-} from 'antd';
+import { Avatar, Button, Card, List, Tooltip } from 'antd';
 import React, { memo, useEffect, useState } from 'react';
 import { TerminalContextProvider } from 'react-terminal';
 import { API } from 'ssm-shared-lib';
 import styles from './Devices.less';
-
-const { Text } = Typography;
-
-export type StateType = {
-  visible?: boolean;
-  done?: boolean;
-  current?: API.DeviceItem;
-};
 
 const Index = memo(() => {
   const [deviceList, setDeviceList] = React.useState<API.DeviceList>({});
@@ -69,14 +46,6 @@ const Index = memo(() => {
   useEffect(() => {
     fetchDeviceList();
   }, []);
-  /*
-  const showModal = () => {
-    setState({
-      visible: true,
-      current: undefined,
-    });
-  };
-*/
 
   const onDropDownClicked = (key: string) => {
     switch (
@@ -85,116 +54,6 @@ const Index = memo(() => {
     ) {
     }
   };
-
-  const ListContent: React.FC<API.DeviceItem> = (props: API.DeviceItem) => (
-    <div className={styles.listContent} key={props.uuid}>
-      <div className={styles.listContentItem}>
-        <span>
-          <DeviceStatusTag status={props.status} />
-        </span>
-        <p>{props.hostname}</p>
-      </div>
-      <div className={styles.listContentItem} style={{ width: '80px' }}>
-        {props.status !== DeviceStatus.UNMANAGED && (
-          <>
-            <p style={{ minWidth: '80px' }}>
-              <WhhCpu /> {props.cpuSpeed?.toFixed(1)} Ghz
-            </p>
-            <p style={{ minWidth: '80px' }}>
-              <WhhRam /> {props.mem ? (props.mem / 1024).toFixed(0) : 'NaN'} Gb
-            </p>
-          </>
-        )}
-      </div>
-      <div className={styles.listContentItem}>
-        {(props.status !== DeviceStatus.UNMANAGED && (
-          <Carousel
-            style={{ width: 300, height: 70, zIndex: 1000 }}
-            dotPosition={'right'}
-            lazyLoad={'progressive'}
-          >
-            <div style={{ width: 300, height: 70, zIndex: 1000 }}>
-              <div
-                style={{
-                  width: 300,
-                  height: 70,
-                  zIndex: 1000,
-                  paddingTop: '15px',
-                }}
-              >
-                <Row style={{ alignItems: 'center' }} justify="center">
-                  <Col span={6}>
-                    <TinyRingProgressDeviceGraph
-                      type={DeviceStatType.CPU}
-                      deviceUuid={props.uuid}
-                    />
-                  </Col>
-                  <Col span={6}>
-                    <TinyRingProgressDeviceGraph
-                      type={DeviceStatType.MEM_USED}
-                      deviceUuid={props.uuid}
-                    />
-                  </Col>
-                  <Col span={6}>
-                    <TinyRingProgressDeviceIndicator
-                      deviceUuid={props.uuid}
-                      type={DeviceStatType.SERVICES}
-                    />
-                  </Col>
-                </Row>
-              </div>
-            </div>
-            <div style={{ width: 300, height: 70, zIndex: 1000 }}>
-              <div style={{ width: 300, height: 70, zIndex: 1000 }}>
-                <Row style={{ alignItems: 'center' }} justify="center">
-                  <Col span={24}>
-                    <TinyLineDeviceGraph
-                      type={DeviceStatType.CPU}
-                      deviceUuid={props.uuid}
-                      from={24}
-                    />
-                  </Col>
-                </Row>
-                <Row>
-                  <Col
-                    span={24}
-                    style={{ marginTop: '-5px', textAlign: 'center' }}
-                  >
-                    <Text type="secondary" style={{ fontSize: '8px' }}>
-                      CPU
-                    </Text>
-                  </Col>
-                </Row>
-              </div>
-            </div>
-            <div style={{ width: 300, height: 70, zIndex: 1000 }}>
-              <div style={{ width: 300, height: 70, zIndex: 1000 }}>
-                <Row style={{ alignItems: 'center' }} justify="center">
-                  <Col span={24}>
-                    <TinyLineDeviceGraph
-                      type={DeviceStatType.MEM_USED}
-                      deviceUuid={props.uuid}
-                      from={24}
-                    />
-                  </Col>
-                </Row>
-                <Row>
-                  <Col
-                    span={24}
-                    style={{ marginTop: '-5px', textAlign: 'center' }}
-                  >
-                    <Text type="secondary" style={{ fontSize: '8px' }}>
-                      MEM USED
-                    </Text>
-                  </Col>
-                </Row>{' '}
-              </div>
-            </div>
-          </Carousel>
-        )) || <div style={{ width: 300, height: 70, zIndex: 1000 }} />}
-      </div>
-    </div>
-  );
 
   return (
     <TerminalContextProvider>
@@ -239,16 +98,17 @@ const Index = memo(() => {
               renderItem={(item) => (
                 <List.Item
                   actions={[
-                    <a
-                      key={`showEditModal-${item.uuid}`}
-                      onClick={(e) => {
-                        e.preventDefault();
+                    <Link
+                      to={{
+                        pathname: `/manage/services`,
+                        search: `deviceUuid=${item.uuid}`,
                       }}
+                      key={`services-${item.uuid}`}
                     >
                       <Tooltip title="Services">
                         <AppstoreOutlined />
                       </Tooltip>
-                    </a>,
+                    </Link>,
                     <Link
                       to={`/admin/inventory/${item.uuid}`}
                       key={`devicesettings-${item.uuid}`}
@@ -270,7 +130,7 @@ const Index = memo(() => {
                     avatar={
                       <Avatar src={OsLogo(item.osLogoFile)} size="large" />
                     }
-                    title={<a href={item.hostname}>{item.hostname}</a>}
+                    title={item.hostname}
                     description={item.ip}
                   />
                   <ListContent

--- a/client/src/pages/Services/components/EditContainerNameModal.tsx
+++ b/client/src/pages/Services/components/EditContainerNameModal.tsx
@@ -1,0 +1,55 @@
+import { updateContainerCustomName } from '@/services/rest/containers';
+import { ActionType, ModalForm, ProFormText } from '@ant-design/pro-components';
+import { message } from 'antd';
+import React from 'react';
+import { API } from 'ssm-shared-lib';
+
+type EditContainerNameModalProps = {
+  isEditContainerCustomNameModalOpened: boolean;
+  setIsEditContainerCustomNameModalOpened: React.Dispatch<
+    React.SetStateAction<boolean>
+  >;
+  selectedRecord?: API.Container;
+  actionRef: React.MutableRefObject<ActionType | undefined>;
+};
+
+const EditContainerNameModal: React.FC<EditContainerNameModalProps> = (
+  props,
+) => {
+  return (
+    <ModalForm<{ customName: string }>
+      title={`Edit container name`}
+      open={props.isEditContainerCustomNameModalOpened}
+      autoFocusFirstInput
+      modalProps={{
+        destroyOnClose: true,
+        onCancel: () => props.setIsEditContainerCustomNameModalOpened(false),
+      }}
+      onFinish={async (values) => {
+        if (!props.selectedRecord) {
+          message.error({ content: 'Internal error, no selected record' });
+          return;
+        }
+        if (props.selectedRecord?.id) {
+          await updateContainerCustomName(
+            values.customName,
+            props.selectedRecord.id,
+          );
+          props.actionRef?.current?.reload();
+          props.setIsEditContainerCustomNameModalOpened(false);
+          message.success({ content: 'Container properties updated' });
+        }
+        return true;
+      }}
+    >
+      <ProFormText
+        name={'customName'}
+        label={'Name'}
+        initialValue={
+          props.selectedRecord?.customName || props.selectedRecord?.name
+        }
+      />
+    </ModalForm>
+  );
+};
+export default EditContainerNameModal;


### PR DESCRIPTION
Moved ContainerMetas component to the 'Device' page directory. ContainerMetas has been given functionality to list containers specific to a device based on a provided device UUID. Likewise, routes are updated to link to this new device-specific container view. Other code cleanups and component restructures are also performed to improve maintainability.