### PR TITLE
[FIX] Refactor extra variable handling and command reference

### DIFF
--- a/client/src/pages/Admin/Inventory/index.tsx
+++ b/client/src/pages/Admin/Inventory/index.tsx
@@ -112,7 +112,7 @@ const Inventory: React.FC = () => {
     setTerminal({
       target: [target],
       isOpen: true,
-      command: '_installAgent',
+      quickRef: 'installAgent',
     });
   };
   const onDeleteNewDevice = async () => {

--- a/server/src/modules/ansible/utils/ExtraVars.ts
+++ b/server/src/modules/ansible/utils/ExtraVars.ts
@@ -42,14 +42,17 @@ async function findValueOfExtraVars(
       logger.error(
         `[INTEGRATION][ANSIBLE] - findValueOfExtraVars - ExtraVar not found : ${e.extraVar}`,
       );
-      throw new Error('ExtraVars value not found !');
+      if (!e.local) {
+        throw new Error('ExtraVars value not found !');
+      }
+    } else {
+      substitutedExtraVars.push({
+        extraVar: e.extraVar,
+        value: value || undefined,
+        required: e.required,
+        canBeOverride: e.canBeOverride,
+      });
     }
-    substitutedExtraVars.push({
-      extraVar: e.extraVar,
-      value: value || undefined,
-      required: e.required,
-      canBeOverride: e.canBeOverride,
-    });
   }
   logger.debug(substitutedExtraVars);
   return substitutedExtraVars;

--- a/shared-lib/src/types/api.ts
+++ b/shared-lib/src/types/api.ts
@@ -547,6 +547,7 @@ export type ExtraVar = {
   value?: string;
   required?: boolean;
   canBeOverride?: boolean;
+  local?: boolean;
 };
 
 export type Image = {


### PR DESCRIPTION
Updated the ExtraVars code to not throw an error when the ExtraVars value is not found and it's local. This update provides better handling of non-local errors and avoids unnecessary alerts for local ones. Additionally, updated the command reference in the terminal from '_installAgent' to 'installAgent' for improved readability.