### PR TITLE
[CHORE] Update SCHEME_VERSION in DefaultValue enum

### DIFF
--- a/shared-lib/src/enums/settings.ts
+++ b/shared-lib/src/enums/settings.ts
@@ -15,7 +15,7 @@ export enum AnsibleReservedExtraVarsKeys {
 }
 
 export enum DefaultValue {
-  SCHEME_VERSION = '7',
+  SCHEME_VERSION = '8',
   SERVER_LOG_RETENTION_IN_DAYS = '30',
   CONSIDER_DEVICE_OFFLINE_AFTER_IN_MINUTES = '3',
   CONSIDER_PERFORMANCE_GOOD_MEM_IF_GREATER = '10',


### PR DESCRIPTION
The SCHEME_VERSION in the DefaultValue enum has been updated from '7' to '8'. This change the version numbers to remain consistent with the overall project versioning scheme.