### PR TITLE
[CHORE] Add become user field to ConnectionVars

### DIFF
--- a/server/src/modules/ansible/utils/InventoryTransformer.ts
+++ b/server/src/modules/ansible/utils/InventoryTransformer.ts
@@ -83,6 +83,7 @@ function getAuth(deviceAuth: Partial<DeviceAuth>): Auth {
 interface ConnectionVars {
   ansible_connection: string;
   ansible_become_method: any;
+  ansible_become_user?: string;
   ansible_become_pass: { __ansible_vault: any };
   ansible_ssh_host_key_checking: boolean;
   ansible_user?: string;
@@ -94,6 +95,7 @@ function getInventoryConnectionVars(deviceAuth: Partial<DeviceAuth>): Connection
   const vars: ConnectionVars = {
     ansible_connection: 'paramiko',
     ansible_become_method: deviceAuth.becomeMethod,
+    ansible_become_user: deviceAuth.becomeUser,
     ansible_become_pass: { __ansible_vault: deviceAuth.becomePass },
     ansible_ssh_host_key_checking: !!deviceAuth.strictHostKeyChecking,
     ansible_user: deviceAuth.sshUser,


### PR DESCRIPTION
Added a new field to the ConnectionVars interface - ansible_become_user, and set its value from the deviceAuth object. This allows setting a specific user for privilege escalation in Ansible.