### PR TITLE
[CHORE] Replace npm install with npm ci in Dockerfiles

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -19,11 +19,11 @@ EXPOSE 8000
 FROM base AS production
 ENV NODE_ENV=production
 COPY . .
-RUN npm install --verbose --no-audit
+RUN npm ci --verbose --no-audit
 RUN npm run build
 CMD ["npm", "run", "serve"]
 
 FROM base AS dev
 COPY . .
-RUN npm install --verbose --no-audit
+RUN npm ci --verbose --no-audit
 CMD ["npm", "run", "start:pre"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,7 +23,7 @@ FROM base AS production
 ENV NODE_ENV=production
 WORKDIR /server
 COPY . .
-RUN npm install --verbose --no-audit
+RUN npm ci --verbose --no-audit
 RUN npm run build
 CMD ["node", "./dist/src/index.js"]
 
@@ -31,5 +31,5 @@ FROM base AS dev
 ENV NODE_ENV=development
 WORKDIR /server
 COPY ./nodemon.json .
-RUN npm install -g nodemon && npm install --verbose --no-audit
+RUN npm install -g nodemon && npm ci --verbose --no-audit
 CMD ["npm", "run", "dev"]


### PR DESCRIPTION
This commit changes the npm command in the server and client Dockerfiles from 'npm install' to 'npm ci' for more reliable, faster builds. This change affects both development and production environments and aims to improve the overall efficiency of the server and client build process.