### PR TITLE
Switch proxy service to use prebuilt Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,7 @@ version: '3.8'
 services:
   proxy:
     restart: unless-stopped
-    build:
-      context: ./proxy
+    image: "ghcr.io/squirrelcorporation/squirrelserversmanager-proxy:latest"
     ports:
       - "8000:8000"
     depends_on:


### PR DESCRIPTION
This change updates the docker-compose configuration to use a prebuilt image from GitHub Container Registry for the proxy service. This will streamline deployments by eliminating the need to build the proxy image locally, ensuring consistency across environments.