### PR TITLE
[CHORE] Update container status handling for unreachable state

### DIFF
--- a/client/src/pages/Services/components/StatusTag.tsx
+++ b/client/src/pages/Services/components/StatusTag.tsx
@@ -1,3 +1,4 @@
+import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { Tag } from 'antd';
 import React from 'react';
 import { SsmStatus } from 'ssm-shared-lib';
@@ -12,6 +13,12 @@ const StatusTag: React.FC<StatusTagProps> = (props: StatusTagProps) => {
       return <Tag color="success">Running</Tag>;
     case SsmStatus.ContainerStatus.PAUSED:
       return <Tag color="warning">Paused</Tag>;
+    case SsmStatus.ContainerStatus.UNREACHABLE:
+      return (
+        <Tag icon={<ExclamationCircleOutlined />} color="default">
+          Unreachable
+        </Tag>
+      );
     default:
       return <Tag>{props.status}</Tag>;
   }

--- a/client/src/pages/Services/components/StatusTag.tsx
+++ b/client/src/pages/Services/components/StatusTag.tsx
@@ -15,7 +15,7 @@ const StatusTag: React.FC<StatusTagProps> = (props: StatusTagProps) => {
       return <Tag color="warning">Paused</Tag>;
     case SsmStatus.ContainerStatus.UNREACHABLE:
       return (
-        <Tag icon={<ExclamationCircleOutlined />} color="default">
+        <Tag icon={<ExclamationCircleOutlined />} color="error">
           Unreachable
         </Tag>
       );

--- a/server/src/data/database/repository/ContainerRepo.ts
+++ b/server/src/data/database/repository/ContainerRepo.ts
@@ -62,6 +62,10 @@ async function count() {
   return await ContainerModel.countDocuments().exec();
 }
 
+async function updateStatusByWatcher(watcher: string, status: string) {
+  await ContainerModel.updateMany({ watcher: watcher }, { status: status }).exec();
+}
+
 export default {
   findContainerById,
   findContainersByWatcher,
@@ -72,4 +76,5 @@ export default {
   countByDeviceId,
   countByStatus,
   count,
+  updateStatusByWatcher,
 };

--- a/server/src/modules/automations/actions/PlaybookActionComponent.ts
+++ b/server/src/modules/automations/actions/PlaybookActionComponent.ts
@@ -55,7 +55,7 @@ class PlaybookActionComponent extends AbstractActionComponent {
   };
 
   async waitForResult(execId: string, timeoutCount = 0) {
-    this.childLogger.info(`wait for result ${execId} - ${timeoutCount}`);
+    this.childLogger.info(`wait for result ${execId} - (try: ${timeoutCount}/100)`);
     try {
       if (timeoutCount > 100) {
         this.childLogger.error('Timeout reached for task');

--- a/shared-lib/src/enums/status.ts
+++ b/shared-lib/src/enums/status.ts
@@ -7,5 +7,6 @@ export enum DeviceStatus {
 
 export enum ContainerStatus {
   RUNNING = 'running',
-  PAUSED = 'paused'
+  PAUSED = 'paused',
+  UNREACHABLE = 'unreachable'
 }


### PR DESCRIPTION
Enhanced logging in PlaybookActionComponent to show retry attempts. Added functionality to update containers' status to 'UNREACHABLE' if Docker API fails, and included new enum value for this status. Updated UI to reflect the new 'UNREACHABLE' status with appropriate icon.