### PR TITLE
[CHORE] Reorder Dockerfile COPY commands for consistency

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -18,12 +18,12 @@ EXPOSE 8000
 
 FROM base AS production
 ENV NODE_ENV=production
-COPY . .
 RUN npm ci --verbose --no-audit
+COPY . .
 RUN npm run build
 CMD ["npm", "run", "serve"]
 
 FROM base AS dev
-COPY . .
 RUN npm ci --verbose --no-audit
+COPY . .
 CMD ["npm", "run", "start:pre"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -22,8 +22,8 @@ EXPOSE 3000
 FROM base AS production
 ENV NODE_ENV=production
 WORKDIR /server
-COPY . .
 RUN npm ci --verbose --no-audit
+COPY . .
 RUN npm run build
 CMD ["node", "./dist/src/index.js"]
 


### PR DESCRIPTION
Moved the COPY command after npm ci in both server and client Dockerfiles. This ensures that dependencies are installed before copying the application code, which can help leverage Docker layer caching more effectively during builds.