### PR TITLE
[CHORE] Update Node.js version in client Dockerfile

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.4.1-alpine AS base
+FROM node:22.5.1-alpine AS base
 LABEL org.opencontainers.image.source=https://github.com/SquirrelCorporation/SquirrelServersManager
 LABEL org.opencontainers.image.description="SSM Client"
 LABEL org.opencontainers.image.licenses="GNU AFFERO GENERAL PUBLIC LICENSE"


### PR DESCRIPTION
Upgraded Node.js base image from version 22.4.1-alpine to 22.5.1-alpine. This update ensures the application benefits from the latest patches and improvements in the Node.js ecosystem. No other changes were made in this commit.