### PR TITLE
[BUG] Remove outdated comment and ensure server initialization

### DIFF
--- a/server/src/App.ts
+++ b/server/src/App.ts
@@ -11,7 +11,7 @@ import routes from './routes';
 
 class AppWrapper {
   protected readonly app = express();
-  private server?: http.Server;
+  private server!: http.Server;
   private socket!: Socket;
 
   constructor() {

--- a/server/src/middlewares/Socket.ts
+++ b/server/src/middlewares/Socket.ts
@@ -50,7 +50,6 @@ export default class Socket {
   };
 
   private authenticateSocketJWT = (req: Request, res: Response, next: NextFunction) => {
-    // @ts-expect-error must complete the req type
     const isHandshake = req._query.sid === undefined;
     if (isHandshake) {
       if (!req.headers?.cookie) {

--- a/server/src/middlewares/Socket.ts
+++ b/server/src/middlewares/Socket.ts
@@ -50,7 +50,7 @@ export default class Socket {
   };
 
   private authenticateSocketJWT = (req: Request, res: Response, next: NextFunction) => {
-    const isHandshake = req._query.sid === undefined;
+    const isHandshake = (req as Request & { _query: { sid: string } })._query.sid === undefined;
     if (isHandshake) {
       if (!req.headers?.cookie) {
         next();


### PR DESCRIPTION
Removed an outdated TypeScript comment in `Socket.ts` to clean up the code. Modified the `App.ts` to enforce the initialization of the `server` property, improving type safety and initialization clarity.