### PR TITLE
[BUG] Fix cron value synchronization in AutomationTriggerInnerCard

### DIFF
--- a/client/src/pages/Automations/components/Drawer/AutomationTriggerInnerCard.tsx
+++ b/client/src/pages/Automations/components/Drawer/AutomationTriggerInnerCard.tsx
@@ -24,11 +24,13 @@ const AutomationTriggerInnerCard: React.FC<AutomationTriggerInnerCardProps> = (
 
   const [cronValue, setCronValue] = React.useState('0 * * * *');
   useEffect(() => {
-    props.formRef?.setFieldValue?.('cronValue', cronValue);
+    if (props.formRef?.getFieldValue('cronValue') !== cronValue) {
+      props.formRef?.setFieldValue?.('cronValue', cronValue);
+    }
   }, [cronValue, props.formRef]);
 
   useEffect(() => {
-    if (newCronValue) {
+    if (newCronValue && newCronValue !== cronValue) {
       setCronValue(newCronValue);
     }
   }, [newCronValue]);


### PR DESCRIPTION
Ensure that the cron value is not redundantly reset if it is already set. Added conditional checks to compare existing cron values, preventing unnecessary state updates.