### PR TITLE
[CHORE] Refactor updateStatus query to use strict equality.

### DIFF
--- a/server/src/data/database/repository/AnsibleTaskRepo.ts
+++ b/server/src/data/database/repository/AnsibleTaskRepo.ts
@@ -9,7 +9,7 @@ async function create(ansibleTask: AnsibleTask): Promise<AnsibleTask> {
 }
 
 async function updateStatus(ident: string, status: string) {
-  return await AnsibleTaskModel.findOneAndUpdate({ ident: ident }, { status: status })
+  return await AnsibleTaskModel.findOneAndUpdate({ ident: { $eq: ident } }, { status: status })
     .lean()
     .exec();
 }


### PR DESCRIPTION
Modified the MongoDB `findOneAndUpdate` query in `updateStatus` function to enforce strict equality on the `ident` field. This ensures that the identification field comparison is precise, reducing potential mismatches.