### PR TITLE
[BUG] Set initial cronValue from formRef

### DIFF
--- a/client/src/pages/Automations/components/Drawer/AutomationTriggerInnerCard.tsx
+++ b/client/src/pages/Automations/components/Drawer/AutomationTriggerInnerCard.tsx
@@ -22,7 +22,11 @@ const AutomationTriggerInnerCard: React.FC<AutomationTriggerInnerCardProps> = (
 ) => {
   const newCronValue = Form.useWatch('cronValue', props.formRef);
 
-  const [cronValue, setCronValue] = React.useState('0 * * * *');
+  const [cronValue, setCronValue] = React.useState(
+    props.formRef?.getFieldValue('cronValue') !== ''
+      ? props.formRef?.getFieldValue('cronValue')
+      : '0 * * * *',
+  );
   useEffect(() => {
     if (props.formRef?.getFieldValue('cronValue') !== cronValue) {
       props.formRef?.setFieldValue?.('cronValue', cronValue);


### PR DESCRIPTION
Previously, cronValue was always initialized to '0 * * * *'. Now, it is set based on the formRef's current value if available, ensuring consistency with existing form data.