### PR TITLE
[BUG] Add support for agent log path management in Ansible tasks

### DIFF
--- a/server/src/ansible/00000000-0000-0000-0000-000000000000/agent/_restartAgent.yml
+++ b/server/src/ansible/00000000-0000-0000-0000-000000000000/agent/_restartAgent.yml
@@ -6,24 +6,31 @@
     base_path: /opt/squirrelserversmanager
 
   tasks:
-    - name: Stop PM2 Agent if running
-      command: pm2 stop agent
-      ignore_errors: yes
-
-    - name: Delete PM2 Agent if present
-      command: pm2 delete agent
-      ignore_errors: yes
+    - name: Manage PM2 Agent
+      block:
+        - name: Stop and Delete PM2 Agent if present
+          command: "pm2 {{ item }} agent"
+          ignore_errors: true
+          with_items:
+            - stop
+            - delete
 
     - name: Start PM2 Agent
-      command:
-        chdir: "{{ base_path }}"
-        cmd: pm2 start -f "./build/agent.js"
+      block:
+        - name: Start PM2 Agent
+          command: pm2 start -f "./build/agent.js"
+          args:
+            chdir: "{{ base_path }}"
 
-    - name: Install PM2 on startup
-      command: pm2 startup
+        - name: Install PM2 on startup
+          command: pm2 startup
 
-    - name: Save Agent on startup
-      command: pm2 save
+        - name: Save Agent on startup
+          command: pm2 save
 
-    - name: Save Agent on startup
-      command: pm2 update
+        - name: Update PM2
+          command: pm2 update
+
+    - name: Task completion summary
+      debug:
+        msg: "Agent restart process completed on {{ inventory_hostname }}"

--- a/server/src/ansible/00000000-0000-0000-0000-000000000000/agent/_retrieveAgentLogs.json
+++ b/server/src/ansible/00000000-0000-0000-0000-000000000000/agent/_retrieveAgentLogs.json
@@ -1,4 +1,12 @@
 {
   "playableInBatch": false,
-  "uniqueQuickRef": "retrieveAgentLogs"
+  "uniqueQuickRef": "retrieveAgentLogs",
+  "extraVars": [
+    {
+      "extraVar": "_ssm_agentLogPath",
+      "required": false,
+      "type": "CONTEXT",
+      "deletable": false
+    }
+  ]
 }

--- a/server/src/ansible/00000000-0000-0000-0000-000000000000/agent/_retrieveAgentLogs.yml
+++ b/server/src/ansible/00000000-0000-0000-0000-000000000000/agent/_retrieveAgentLogs.yml
@@ -1,0 +1,37 @@
+- name: Optionally read logs from a specified path
+  hosts: all
+  become: yes
+  gather_facts: no
+
+  tasks:
+    - name: Check if the log path is provided
+      ansible.builtin.debug:
+        msg: "Log path: {{ _ssm_agentLogPath }}"
+      when: _ssm_agentLogPath is defined and _ssm_agentLogPath != ""
+
+    - name: Verify the log file exists
+      ansible.builtin.stat:
+        path: "{{ _ssm_agentLogPath }}"
+      register: log_file
+      when: _ssm_agentLogPath is defined and _ssm_agentLogPath != ""
+
+    - name: Read the log file
+      ansible.builtin.shell: "cat {{ _ssm_agentLogPath }}"
+      register: log_content
+      when:
+        - _ssm_agentLogPath is defined and _ssm_agentLogPath != ""
+        - log_file.stat.exists
+        - log_file.stat.isfile
+
+    - name: Print the log content
+      ansible.builtin.debug:
+        msg: "{{ log_content.stdout }}"
+      when:
+        - _ssm_agentLogPath is defined and _ssm_agentLogPath != ""
+        - log_file.stat.exists
+        - log_file.stat.isfile
+
+    - name: Log path not defined or invalid
+      ansible.builtin.debug:
+        msg: "The log path is either not defined or points to an invalid file."
+      when: _ssm_agentLogPath is not defined or _ssm_agentLogPath == ""

--- a/server/src/ansible/00000000-0000-0000-0000-000000000000/agent/_uninstallAgent.json
+++ b/server/src/ansible/00000000-0000-0000-0000-000000000000/agent/_uninstallAgent.json
@@ -1,4 +1,12 @@
 {
   "playableInBatch": false,
-  "uniqueQuickRef": "uninstallAgent"
+  "uniqueQuickRef": "uninstallAgent",
+  "extraVars": [
+    {
+      "extraVar": "_ssm_agentLogPath",
+      "required": false,
+      "type": "CONTEXT",
+      "deletable": false
+    }
+  ]
 }

--- a/server/src/ansible/00000000-0000-0000-0000-000000000000/agent/_uninstallAgent.yml
+++ b/server/src/ansible/00000000-0000-0000-0000-000000000000/agent/_uninstallAgent.yml
@@ -4,18 +4,34 @@
   gather_facts: false
   vars:
     shell_script: undef
+    agent_log_path: "{{ _ssm_agentLogPath | default(omit) }}"
 
   tasks:
-    - name: Stop PM2 Agent if running
-      command: pm2 stop agent
-      ignore_errors: yes
+    - name: Manage PM2 Agent
+      block:
+        - name: Stop PM2 Agent if running
+          command: pm2 stop agent
+          ignore_errors: true
 
-    - name: Delete PM2 Agent if present
-      command: pm2 delete agent
-      ignore_errors: yes
+        - name: Delete PM2 Agent if present
+          command: pm2 delete agent
+          ignore_errors: true
 
-    - name: Recursively remove directory
-      ansible.builtin.file:
-        path: /opt/squirrelserversmanager
-        state: absent
-      timeout: 600
+    - name: Remove Agent Directory
+      block:
+        - name: Recursively remove Squirrel Servers Manager directory
+          ansible.builtin.file:
+            path: /opt/squirrelserversmanager
+            state: absent
+          timeout: 600
+
+        - name: Delete the log directory
+          ansible.builtin.file:
+            path: "{{ agent_log_path }}"
+            state: absent
+          ignore_errors: true
+          when: agent_log_path is defined and agent_log_path | regex_search('/logs')
+
+    - name: Task completion summary
+      debug:
+        msg: "Agent uninstallation completed on {{ inventory_hostname }}"

--- a/server/src/ansible/00000000-0000-0000-0000-000000000000/device/_upgrade.yml
+++ b/server/src/ansible/00000000-0000-0000-0000-000000000000/device/_upgrade.yml
@@ -1,4 +1,5 @@
-- hosts: all
+- name: Perform system upgrade and cleanup with conditional reboot
+  hosts: all
   gather_facts: yes
   become: yes
 

--- a/server/src/modules/ansible/SmartFailure.ts
+++ b/server/src/modules/ansible/SmartFailure.ts
@@ -91,6 +91,47 @@ const failurePatterns: FailurePattern[] = [
     resolution:
       'Check the configuration and parameters of the redirect module used in the playbook.',
   },
+  {
+    id: 'docker_connection_failed',
+    pattern: /Failed to connect to Docker daemon/i,
+    cause:
+      'Ansible failed to connect to the Docker daemon, which could be due to the Docker service not running or permission issues.',
+    resolution:
+      'Ensure the Docker service is running on the host.\n' +
+      '1. Verify Docker daemon is active using: `sudo systemctl status docker`\n' +
+      '2. Check if the user has the necessary permissions to interact with Docker. Users usually need to be added to the "docker" group: `sudo usermod -aG docker $USER`\n' +
+      '3. Restart the Docker service: `sudo systemctl restart docker`',
+  },
+  {
+    id: 'container_not_found',
+    pattern: /No such container/i,
+    cause: 'The specified Docker container does not exist on the host.',
+    resolution:
+      'Verify that the container name or ID is correct and that the container is running.\n' +
+      '1. List all containers to confirm: `docker ps -a`\n' +
+      '2. Ensure the container name or ID used in the playbook matches one of the listed containers.',
+  },
+  {
+    id: 'image_pull_failed',
+    pattern: /Failed to pull image/i,
+    cause: 'Ansible failed to pull the specified Docker image from the registry.',
+    resolution:
+      'Check the Docker image name and tag for correctness.\n' +
+      '1. Ensure the image name and tag are correct and available in the registry: `docker pull <image_name>:<tag>`\n' +
+      '2. Verify that you have the necessary permissions to pull from the registry (e.g., docker login).\n' +
+      '3. Check your network connection to ensure it can reach the Docker registry.',
+  },
+  {
+    id: 'docker_execution_failed',
+    pattern: /Failed to execute command in container/i,
+    cause:
+      'Ansible could not execute a command inside the Docker container due to various possible issues.',
+    resolution:
+      'Check the command and container’s state.\n' +
+      '1. Ensure the container is running: `docker ps`\n' +
+      '2. Verify the command is valid within the container’s environment.\n' +
+      '3. Check the container logs for additional error details: `docker logs <container_id>`',
+  },
 ];
 
 class SmartFailure {

--- a/server/src/modules/ansible/extravars/ExtraVars.ts
+++ b/server/src/modules/ansible/extravars/ExtraVars.ts
@@ -81,6 +81,8 @@ class ExtraVars {
         return targets[0];
       case SsmAnsible.DefaultContextExtraVarsList.DEVICE_IP:
         return device.ip;
+      case SsmAnsible.DefaultContextExtraVarsList.AGENT_LOG_PATH:
+        return device.agentLogPath;
     }
     this.logger.error(`Context variable not found: '${extraVar.extraVar}'`);
   }

--- a/shared-lib/src/enums/ansible.ts
+++ b/shared-lib/src/enums/ansible.ts
@@ -7,6 +7,7 @@ export enum ExtraVarsType {
 export enum DefaultContextExtraVarsList {
   DEVICE_ID = '_ssm_deviceId',
   DEVICE_IP = '_ssm_deviceIP',
+  AGENT_LOG_PATH = '_ssm_agentLogPath',
 }
 
 export enum DefaultSharedExtraVarsList {


### PR DESCRIPTION
Introduced a new context variable `_ssm_agentLogPath` for handling agent log paths across various Ansible playbooks. Updated the uninstall, retrieve logs, and restart tasks to manage agent logs more effectively, including conditional log path handling and cleanup. Enhanced error management and user feedback for Docker connection issues.