### PR TITLE
Update playbooks.json and add Ansible smart failure endpoint

### DIFF
--- a/server-demo/src/data/ansible-smart-failure.json
+++ b/server-demo/src/data/ansible-smart-failure.json
@@ -1,0 +1,6 @@
+{
+  "id": "unreachable",
+  "message": "fatal: [192.168.0.69]: UNREACHABLE! => {",
+  "cause": "The device may be down or unreachable.",
+  "resolution": "Check the device network connectivity and ensure you entered the right IP."
+}

--- a/server-demo/src/data/playbooks.json
+++ b/server-demo/src/data/playbooks.json
@@ -8,12 +8,12 @@
         {
           "extraVar": "project",
           "required": true,
-          "canBeOverride": true
+          "type": "MANUAL"
         },
         {
           "extraVar": "definition",
           "required": true,
-          "canBeOverride": true
+          "type": "MANUAL"
         }
       ],
       "name": "_dockerCompose.yml",
@@ -136,7 +136,7 @@
         {
           "extraVar": "_ssm_masterNodeUrl",
           "required": true,
-          "canBeOverride": true
+          "type": "SHARED"
         }
       ],
       "name": "pingSsmApiUrl.yml",
@@ -437,12 +437,12 @@
         {
           "extraVar": "_ssm_masterNodeUrl",
           "required": true,
-          "canBeOverride": true
+          "type": "SHARED"
         },
         {
           "extraVar": "_ssm_deviceId",
           "required": true,
-          "canBeOverride": false
+          "type": "CONTEXT"
         }
       ],
       "name": "_reinstallAgent.yml",
@@ -799,12 +799,12 @@
         {
           "extraVar": "_ssm_masterNodeUrl",
           "required": true,
-          "canBeOverride": true
+          "type": "SHARED"
         },
         {
           "extraVar": "_ssm_deviceId",
           "required": true,
-          "canBeOverride": false
+          "type": "CONTEXT"
         }
       ],
       "name": "_updateAgent.yml",
@@ -927,12 +927,12 @@
         {
           "extraVar": "_ssm_masterNodeUrl",
           "required": true,
-          "canBeOverride": true
+          "type": "SHARED"
         },
         {
           "extraVar": "_ssm_deviceId",
           "required": true,
-          "canBeOverride": false
+          "type": "CONTEXT"
         }
       ],
       "name": "_installAgent.yml",
@@ -1406,7 +1406,7 @@
         {
           "extraVar": "_ssm_masterNodeUrl",
           "required": true,
-          "canBeOverride": true
+          "type": "SHARED"
         }
       ],
       "name": "_checkDeviceBeforeAdd.yml",
@@ -1529,7 +1529,7 @@
         {
           "extraVar": "_ssm_masterNodeUrl",
           "required": true,
-          "canBeOverride": true
+          "type": "SHARED"
         }
       ],
       "playableInBatch": false,
@@ -1571,12 +1571,12 @@
         {
           "extraVar": "_ssm_masterNodeUrl",
           "required": true,
-          "canBeOverride": true
+          "type": "SHARED"
         },
         {
           "extraVar": "_ssm_deviceId",
           "required": true,
-          "canBeOverride": false
+          "type": "CONTEXT"
         }
       ],
       "playableInBatch": false,
@@ -1627,12 +1627,12 @@
         {
           "extraVar": "_ssm_masterNodeUrl",
           "required": true,
-          "canBeOverride": true
+          "type": "SHARED"
         },
         {
           "extraVar": "_ssm_deviceId",
           "required": true,
-          "canBeOverride": false
+          "type": "CONTEXT"
         }
       ],
       "playableInBatch": false,

--- a/server-demo/src/routes/ansible.ts
+++ b/server-demo/src/routes/ansible.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import ansibleConf from "../data/ansible-conf.json";
+import smartFailure from "../data/ansible-smart-failure.json";
 import { SuccessResponse } from "../utils/ApiResponse";
 import asyncHandler from "../utils/AsyncHandler";
 
@@ -9,6 +10,13 @@ router.get(
   "/ansible/config",
   asyncHandler(async (req, res) => {
     new SuccessResponse("Got Ansible Conf", ansibleConf).send(res);
+  }),
+);
+
+router.get(
+  "/ansible/smart-failure",
+  asyncHandler(async (req, res) => {
+    new SuccessResponse("May got Ansible SmartFailure", smartFailure).send(res);
   }),
 );
 


### PR DESCRIPTION
Replaced 'canBeOverride' properties with 'type' in playbooks.json for better clarity and precision. Added new Ansible smart failure endpoint and created ansible-smart-failure.json to handle specific unreachable device scenarios.