### PR TITLE
[BUG] Refactor Ansible keys usage in cache settings

### DIFF
--- a/server/src/controllers/rest/devices/device.ts
+++ b/server/src/controllers/rest/devices/device.ts
@@ -1,5 +1,5 @@
-import { API, SettingsKeys, SsmStatus } from 'ssm-shared-lib';
 import { parse } from 'url';
+import { API, SsmAnsible, SsmStatus } from 'ssm-shared-lib';
 import { setToCache } from '../../../data/cache';
 import Device from '../../../data/database/model/Device';
 import DeviceAuth from '../../../data/database/model/DeviceAuth';
@@ -31,7 +31,7 @@ export const addDevice = asyncHandler(async (req, res) => {
     sshKeyPass,
   } = req.body;
   if (masterNodeUrl) {
-    await setToCache(SettingsKeys.AnsibleReservedExtraVarsKeys.MASTER_NODE_URL, masterNodeUrl);
+    await setToCache(SsmAnsible.DefaultSharedExtraVarsList.MASTER_NODE_URL, masterNodeUrl);
   }
   try {
     const isUnManagedDevice = unManaged === true;

--- a/server/src/services/DeviceUseCases.ts
+++ b/server/src/services/DeviceUseCases.ts
@@ -1,6 +1,6 @@
 import DockerModem from 'docker-modem';
 import Dockerode from 'dockerode';
-import { API, SettingsKeys, SsmAnsible, SsmStatus } from 'ssm-shared-lib';
+import { API, SsmAnsible, SsmStatus } from 'ssm-shared-lib';
 import { setToCache } from '../data/cache';
 import Device, { DeviceModel } from '../data/database/model/Device';
 import DeviceAuth from '../data/database/model/DeviceAuth';
@@ -142,7 +142,7 @@ async function checkAnsibleConnection(
   sshKeyPass?: string,
 ) {
   if (masterNodeUrl) {
-    await setToCache(SettingsKeys.AnsibleReservedExtraVarsKeys.MASTER_NODE_URL, masterNodeUrl);
+    await setToCache(SsmAnsible.DefaultSharedExtraVarsList.MASTER_NODE_URL, masterNodeUrl);
   }
   if (sshKey) {
     await Shell.SshPrivateKeyFileManager.saveSshKey(sshKey, 'tmp');

--- a/shared-lib/src/enums/settings.ts
+++ b/shared-lib/src/enums/settings.ts
@@ -10,10 +10,6 @@ export enum GeneralSettingsKeys {
   CONTAINER_STATS_RETENTION_IN_DAYS = 'container-stats-retention-in-days',
 }
 
-export enum AnsibleReservedExtraVarsKeys {
-  MASTER_NODE_URL = 'ansible-master-node-url',
-}
-
 export enum DefaultValue {
   SCHEME_VERSION = '11',
   SERVER_LOG_RETENTION_IN_DAYS = '30',


### PR DESCRIPTION
Replaced AnsibleReservedExtraVarsKeys with DefaultSharedExtraVarsList for master node URL. Updated imports and references accordingly in DeviceUseCases and device controller. Removed obsolete enum from settings.