### PR TITLE
[FEAT] Add ability to use automatic SSH authentication

### DIFF
--- a/server/src/controllers/rest/devices/check-connection.validator.ts
+++ b/server/src/controllers/rest/devices/check-connection.validator.ts
@@ -13,11 +13,18 @@ export const postCheckAnsibleConnectionValidator = [
     .exists()
     .withMessage('sshConnection in body is required')
     .isIn(Object.values(SsmAnsible.SSHConnection))
-    .withMessage('sshConnection is not in enum value SSHConnection'),
+    .withMessage('sshConnection is not in enum value SSHConnection')
+    .if(body('authType').equals(SsmAnsible.SSHType.Automatic))
+    .isIn([SsmAnsible.SSHConnection.BUILTIN])
+    .withMessage('sshConnection must be ssh with automatic authentication'),
   body('authType')
     .exists()
     .withMessage('authType in body is required')
-    .isIn([SsmAnsible.SSHType.UserPassword, SsmAnsible.SSHType.KeyBased])
+    .isIn([
+      SsmAnsible.SSHType.UserPassword,
+      SsmAnsible.SSHType.KeyBased,
+      SsmAnsible.SSHType.Automatic,
+    ])
     .withMessage('authType is not in enum value SSHType'),
   body('sshPort').exists().notEmpty().isNumeric().withMessage('sshPort is not a number'),
   body('unManaged').optional().isBoolean().withMessage('unManaged is not a boolean'),
@@ -32,7 +39,7 @@ export const postCheckAnsibleConnectionValidator = [
     .notEmpty()
     .isString(),
   body('sshUser')
-    .if(body('authType').equals(SsmAnsible.SSHType.UserPassword))
+    .if(body('authType').isIn([SsmAnsible.SSHType.UserPassword, SsmAnsible.SSHType.Automatic]))
     .exists()
     .notEmpty()
     .isString(),
@@ -54,7 +61,11 @@ export const postCheckDockerConnectionValidator = [
   body('authType')
     .exists()
     .withMessage('authType in body is required')
-    .isIn([SsmAnsible.SSHType.UserPassword, SsmAnsible.SSHType.KeyBased])
+    .isIn([
+      SsmAnsible.SSHType.UserPassword,
+      SsmAnsible.SSHType.KeyBased,
+      SsmAnsible.SSHType.Automatic,
+    ])
     .withMessage('authType is not in enum value SSHType'),
   body('sshPort').exists().notEmpty().isNumeric().withMessage('sshPort is not a number'),
   body('sshKey')
@@ -63,7 +74,7 @@ export const postCheckDockerConnectionValidator = [
     .notEmpty()
     .isString(),
   body('sshUser')
-    .if(body('authType').equals(SsmAnsible.SSHType.UserPassword))
+    .if(body('authType').isIn([SsmAnsible.SSHType.UserPassword, SsmAnsible.SSHType.Automatic]))
     .exists()
     .notEmpty()
     .isString(),

--- a/server/src/controllers/rest/devices/device.validator.ts
+++ b/server/src/controllers/rest/devices/device.validator.ts
@@ -12,8 +12,12 @@ export const addDeviceValidator = [
   body('authType')
     .exists()
     .withMessage('authType in body is required')
-    .isIn([SsmAnsible.SSHType.UserPassword, SsmAnsible.SSHType.KeyBased])
+    .isIn(Object.values(SsmAnsible.SSHType))
     .withMessage('authType is not in enum value SSHType'),
+  body('sshConnection')
+    .if(body('authType').equals(SsmAnsible.SSHType.Automatic))
+    .isIn([SsmAnsible.SSHConnection.BUILTIN, undefined])
+    .withMessage('sshConnection must be "ssh" for automatic authentication'),
   body('sshPort').exists().notEmpty().isNumeric().withMessage('sshPort is not a number'),
   body('unManaged').optional().isBoolean().withMessage('unManaged is not a boolean'),
   body('masterNodeUrl')
@@ -27,7 +31,7 @@ export const addDeviceValidator = [
     .notEmpty()
     .isString(),
   body('sshUser')
-    .if(body('authType').equals(SsmAnsible.SSHType.UserPassword))
+    .if(body('authType').isIn([SsmAnsible.SSHType.UserPassword, SsmAnsible.SSHType.Automatic]))
     .exists()
     .notEmpty()
     .isString(),

--- a/server/src/controllers/rest/devices/deviceauth.validator.ts
+++ b/server/src/controllers/rest/devices/deviceauth.validator.ts
@@ -37,7 +37,7 @@ export const addOrUpdateDeviceAuthValidator = [
     .notEmpty()
     .isString(),
   body('sshUser')
-    .if(body('authType').equals(SsmAnsible.SSHType.UserPassword))
+    .if(body('authType').isIn([SsmAnsible.SSHType.UserPassword, SsmAnsible.SSHType.Automatic]))
     .exists()
     .notEmpty()
     .isString(),
@@ -51,6 +51,10 @@ export const addOrUpdateDeviceAuthValidator = [
     .notEmpty()
     .isIn(Object.values(SsmAnsible.AnsibleBecomeMethod))
     .withMessage('becomeMethod is not supported'),
+  body('sshConnection')
+    .if(body('authType').equals(SsmAnsible.SSHType.Automatic))
+    .isIn([SsmAnsible.SSHConnection.BUILTIN, undefined])
+    .withMessage('sshConnection must be "ssh" for automatic authentication'),
   validator,
 ];
 

--- a/server/src/helpers/ssh/SSHCredentialsHelper.ts
+++ b/server/src/helpers/ssh/SSHCredentialsHelper.ts
@@ -75,17 +75,25 @@ class SSHCredentialsHelper {
     sshKeyPass?: string,
   ): Promise<ConnectConfig> {
     let sshCredentials: ConnectConfig = {};
-    if (authType === SSHType.KeyBased) {
-      sshCredentials = {
-        username: sshUsername,
-        privateKey: sshKey ? await vaultDecrypt(sshKey, DEFAULT_VAULT_ID) : undefined,
-        passphrase: sshKeyPass ? await vaultDecrypt(sshKeyPass, DEFAULT_VAULT_ID) : undefined,
-      };
-    } else if (authType === SSHType.UserPassword) {
-      sshCredentials = {
-        username: sshUsername,
-        password: sshPwd ? await vaultDecrypt(sshPwd, DEFAULT_VAULT_ID) : undefined,
-      };
+    switch (authType) {
+      case SSHType.Automatic:
+        sshCredentials = {
+          username: sshUsername,
+        };
+        break;
+      case SSHType.KeyBased:
+        sshCredentials = {
+          username: sshUsername,
+          privateKey: sshKey ? await vaultDecrypt(sshKey, DEFAULT_VAULT_ID) : undefined,
+          passphrase: sshKeyPass ? await vaultDecrypt(sshKeyPass, DEFAULT_VAULT_ID) : undefined,
+        };
+        break;
+      case SSHType.UserPassword:
+        sshCredentials = {
+          username: sshUsername,
+          password: sshPwd ? await vaultDecrypt(sshPwd, DEFAULT_VAULT_ID) : undefined,
+        };
+        break;
     }
     return sshCredentials;
   }

--- a/server/src/tests/unit-tests/helpers/ssh/SSHCredentialsHelper.test.ts
+++ b/server/src/tests/unit-tests/helpers/ssh/SSHCredentialsHelper.test.ts
@@ -100,6 +100,30 @@ describe('SSHCredentialsHelper', () => {
     expect(vault.vaultDecrypt).toHaveBeenCalledTimes(1);
   });
 
+  test('should handle automatic SSHType for default Docker SSH', async () => {
+    deviceAuth.authType = SsmAnsible.SSHType.Automatic;
+
+    const result = await SSHCredentialsHelper.getDockerSshConnectionOptions(device, deviceAuth);
+
+    expect(result).toMatchObject({
+      protocol: 'ssh',
+      port: 22,
+      username: 'apiuser',
+      host: '0.0.0.0',
+      _deviceUuid: 'x',
+      sshOptions: {
+        tryKeyboard: true,
+        forceIPv4: undefined,
+        forceIPv6: undefined,
+        host: '0.0.0.0',
+        port: 22,
+        username: 'apiuser',
+      },
+    });
+
+    expect(vault.vaultDecrypt).toHaveBeenCalledTimes(0);
+  });
+
   test('should handle key-based SSHType for custom Docker SSH', async () => {
     deviceAuth.authType = SsmAnsible.SSHType.UserPassword;
     deviceAuth.sshPwd = 'sshpwd';
@@ -160,5 +184,33 @@ describe('SSHCredentialsHelper', () => {
     });
 
     expect(vault.vaultDecrypt).toHaveBeenCalledTimes(1);
+  });
+
+  test('should handle automatic SSHType for custom Docker SSH', async () => {
+    deviceAuth.authType = SsmAnsible.SSHType.UserPassword;
+    deviceAuth.sshPwd = 'sshpwd';
+    deviceAuth.customDockerSSH = true;
+    deviceAuth.dockerCustomAuthType = SsmAnsible.SSHType.Automatic;
+    deviceAuth.dockerCustomSshUser = '$customUser';
+
+    const result = await SSHCredentialsHelper.getDockerSshConnectionOptions(device, deviceAuth);
+
+    expect(result).toMatchObject({
+      protocol: 'ssh',
+      port: 22,
+      username: 'apiuser',
+      host: '0.0.0.0',
+      _deviceUuid: 'x',
+      sshOptions: {
+        tryKeyboard: true,
+        forceIPv4: undefined,
+        forceIPv6: undefined,
+        host: '0.0.0.0',
+        port: 22,
+        username: '$customUser',
+      },
+    });
+
+    expect(vault.vaultDecrypt).toHaveBeenCalledTimes(0);
   });
 });

--- a/shared-lib/src/enums/ansible.ts
+++ b/shared-lib/src/enums/ansible.ts
@@ -17,6 +17,7 @@ export enum DefaultSharedExtraVarsList {
 export enum SSHType {
   UserPassword = 'userPwd',
   KeyBased = 'keyBased',
+  Automatic = 'automatic',
 }
 
 export enum SSHConnection {


### PR DESCRIPTION
I use tailscale to connect my nodes together because they exist on different networks. I'd still like to be able to use SSM to monitor and manage them. Since tailscale does not use a password, even regular SSH connection fail.

This change adds the ability to have an automatic (open to other names, if preferred) SSH connection that only needs a username. This is not supported by `paramiko`, so using automatic authentication requires the use of the built-in SSH connection type.

I've done my best to add tests and do manual testing with the dev docker-compose file. Please let me know if there are other tests needed or if there are any naming or architectural changes you'd prefer.