### PR TITLE
[BUG] Add getAllDevices API endpoint and update client calls

### DIFF
--- a/client/src/pages/Automations/components/Drawer/PlaybookActionSubForm.tsx
+++ b/client/src/pages/Automations/components/Drawer/PlaybookActionSubForm.tsx
@@ -1,5 +1,5 @@
 import ExtraVarView from '@/components/PlaybookSelection/ExtraVarView';
-import { getDevices } from '@/services/rest/device';
+import { getAllDevices } from '@/services/rest/device';
 import { getPlaybooks } from '@/services/rest/playbooks';
 import { CheckCircleFilled, FileOutlined, LockFilled } from '@ant-design/icons';
 import { ProFormSelect } from '@ant-design/pro-components';
@@ -126,7 +126,7 @@ const PlaybookActionSubForm: React.FC<PlaybookActionSubFormProps> = (props) => {
           { required: true, message: 'Please select at least one device!' },
         ]}
         request={async () => {
-          return getDevices().then((response) => {
+          return getAllDevices().then((response) => {
             return response.data.map((e: API.DeviceItem) => {
               return { label: `${e.fqdn} (${e.ip})`, value: e.uuid };
             });

--- a/client/src/pages/Containers/components/Images.tsx
+++ b/client/src/pages/Containers/components/Images.tsx
@@ -1,4 +1,4 @@
-import { getDevices } from '@/services/rest/device';
+import { getAllDevices } from '@/services/rest/device';
 import { getImages } from '@/services/rest/services';
 import { PlusOutlined } from '@ant-design/icons';
 import {
@@ -49,7 +49,7 @@ const Images: React.FC = () => {
       renderFormItem: () => (
         <ProFormSelect
           request={async () => {
-            return await getDevices().then((e: API.DeviceList) => {
+            return await getAllDevices().then((e: API.DeviceList) => {
               return e.data?.map((f: API.DeviceItem) => {
                 return {
                   label: `${f.fqdn} (${f.ip})`,

--- a/client/src/pages/Containers/components/Networks.tsx
+++ b/client/src/pages/Containers/components/Networks.tsx
@@ -1,6 +1,6 @@
 import { Bridge, GrommetIconsHost } from '@/components/Icons/CustomIcons';
 import CreateNetworkModal from '@/pages/Containers/components/sub-components/CreateNetworkModal';
-import { getDevices } from '@/services/rest/device';
+import { getAllDevices } from '@/services/rest/device';
 import { getNetworks } from '@/services/rest/services';
 import {
   ProColumns,
@@ -26,7 +26,7 @@ const Networks: React.FC = () => {
       renderFormItem: () => (
         <ProFormSelect
           request={async () => {
-            return await getDevices().then((e: API.DeviceList) => {
+            return await getAllDevices().then((e: API.DeviceList) => {
               return e.data?.map((f: API.DeviceItem) => {
                 return {
                   label: `${f.fqdn} (${f.ip})`,

--- a/client/src/pages/Containers/components/Volumes.tsx
+++ b/client/src/pages/Containers/components/Volumes.tsx
@@ -1,5 +1,5 @@
 import CreateVolumeModal from '@/pages/Containers/components/sub-components/CreateVolumeModal';
-import { getDevices } from '@/services/rest/device';
+import { getAllDevices } from '@/services/rest/device';
 import { getVolumes } from '@/services/rest/services';
 import {
   ActionType,
@@ -27,7 +27,7 @@ const Volumes: React.FC = () => {
       renderFormItem: () => (
         <ProFormSelect
           request={async () => {
-            return await getDevices().then((e: API.DeviceList) => {
+            return await getAllDevices().then((e: API.DeviceList) => {
               return e.data?.map((f: API.DeviceItem) => {
                 return {
                   label: `${f.fqdn} (${f.ip})`,

--- a/client/src/pages/Containers/components/containers/ContainerMetas.tsx
+++ b/client/src/pages/Containers/components/containers/ContainerMetas.tsx
@@ -9,7 +9,7 @@ import InfoToolTipCard from '@/pages/Containers/components/containers/InfoToolTi
 import StatusTag from '@/pages/Containers/components/containers/StatusTag';
 import UpdateAvailableTag from '@/pages/Containers/components/containers/UpdateAvailableTag';
 import { postContainerAction } from '@/services/rest/containers';
-import { getDevices } from '@/services/rest/device';
+import { getAllDevices } from '@/services/rest/device';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import {
   ProFieldValueType,
@@ -133,7 +133,7 @@ const ContainerMetas = (props: ContainerMetasProps) => {
       renderFormItem: () => (
         <ProFormSelect
           request={async () => {
-            return await getDevices().then((e: API.DeviceList) => {
+            return await getAllDevices().then((e: API.DeviceList) => {
               return e.data?.map((f: API.DeviceItem) => {
                 return {
                   label: `${f.fqdn} (${f.ip})`,

--- a/client/src/pages/Containers/components/sub-components/CreateNetworkModal.tsx
+++ b/client/src/pages/Containers/components/sub-components/CreateNetworkModal.tsx
@@ -8,7 +8,7 @@ import {
   Vlan,
 } from '@/components/Icons/CustomIcons';
 import DockerOpsModal from '@/pages/Containers/components/sub-components/DockerOpsModal';
-import { getDevices } from '@/services/rest/device';
+import { getAllDevices } from '@/services/rest/device';
 import { postNetwork } from '@/services/rest/services';
 import { cidrContains, isCidr, isIp, isNetworkBaseAddress } from '@/utils/ip';
 import {
@@ -583,7 +583,7 @@ const CreateNetworkModal = () => {
           }}
           placeholder={'Please select a target'}
           request={async () => {
-            return getDevices().then((e) => {
+            return getAllDevices().then((e) => {
               return e?.data?.map((device: API.DeviceItem) => ({
                 label: `${device.fqdn} (${device.ip})`,
                 value: device.uuid,

--- a/client/src/pages/Containers/components/sub-components/CreateVolumeModal.tsx
+++ b/client/src/pages/Containers/components/sub-components/CreateVolumeModal.tsx
@@ -1,6 +1,6 @@
 import { ContainerVolumeSolid, Target } from '@/components/Icons/CustomIcons';
 import DockerOpsModal from '@/pages/Containers/components/sub-components/DockerOpsModal';
-import { getDevices } from '@/services/rest/device';
+import { getAllDevices } from '@/services/rest/device';
 import { postVolume } from '@/services/rest/services';
 import { CheckCircleFilled, PlusOutlined } from '@ant-design/icons';
 import {
@@ -76,7 +76,7 @@ const CreateVolumeModal = () => {
           }}
           placeholder={'Please select a target'}
           request={async () => {
-            return getDevices().then((e) => {
+            return getAllDevices().then((e) => {
               return e?.data?.map((device: API.DeviceItem) => ({
                 label: `${device.fqdn} (${device.ip})`,
                 value: device.uuid,

--- a/client/src/pages/Containers/components/sub-components/DeployCustomStackModal.tsx
+++ b/client/src/pages/Containers/components/sub-components/DeployCustomStackModal.tsx
@@ -2,7 +2,7 @@ import { StackIcon } from '@/components/ComposeEditor/StackIconSelector';
 import { Target } from '@/components/Icons/CustomIcons';
 import DockerOpsModal from '@/pages/Containers/components/sub-components/DockerOpsModal';
 import { postDeployContainerCustomStack } from '@/services/rest/containers';
-import { getDevices } from '@/services/rest/device';
+import { getAllDevices } from '@/services/rest/device';
 import { CheckCircleFilled, RocketOutlined } from '@ant-design/icons';
 import {
   ModalForm,
@@ -96,7 +96,7 @@ const DeployCustomStackModal: React.FC<DeployCustomStackModalProps> = ({
           }}
           placeholder={'Please select a target'}
           request={async () => {
-            return getDevices().then((e) => {
+            return getAllDevices().then((e) => {
               return e?.data?.map((device: API.DeviceItem) => ({
                 label: `${device.fqdn} (${device.ip})`,
                 value: device.uuid,

--- a/client/src/pages/Containers/components/sub-components/DeployModal.tsx
+++ b/client/src/pages/Containers/components/sub-components/DeployModal.tsx
@@ -6,7 +6,7 @@ import ProCardLabelsConfiguration from '@/pages/Containers/components/sub-compon
 import ProCardPortsConfiguration from '@/pages/Containers/components/sub-components/deploy-configuration-forms/ProCardPortsConfiguration';
 import ProCardVolumesConfiguration from '@/pages/Containers/components/sub-components/deploy-configuration-forms/ProCardVolumesConfiguration';
 import DockerOpsModal from '@/pages/Containers/components/sub-components/DockerOpsModal';
-import { getDevices } from '@/services/rest/device';
+import { getAllDevices } from '@/services/rest/device';
 import { postDeploy } from '@/services/rest/services';
 import { CheckCircleFilled } from '@ant-design/icons';
 import {
@@ -151,7 +151,7 @@ const DeployModal: React.FC<DeployModalProps> = (props: DeployModalProps) => {
           }}
           placeholder={'Please select a target'}
           request={async () => {
-            return getDevices().then((e) => {
+            return getAllDevices().then((e) => {
               return e.data.map((device: API.DeviceItem) => ({
                 label: `${device.fqdn} (${device.ip})`,
                 value: device.uuid,

--- a/client/src/services/rest/device.ts
+++ b/client/src/services/rest/device.ts
@@ -16,6 +16,19 @@ export async function getDevices(
   });
 }
 
+export async function getAllDevices(
+  params?: API.PageParams,
+  options?: { [key: string]: any },
+) {
+  return request<API.DeviceList>('/api/devices/all', {
+    method: 'GET',
+    params: {
+      ...params,
+    },
+    ...(options || {}),
+  });
+}
+
 export async function putDevice(
   ip: string,
   deviceAuth: API.DeviceAuthParams,

--- a/server/src/controllers/rest/devices/device.ts
+++ b/server/src/controllers/rest/devices/device.ts
@@ -152,3 +152,12 @@ export const updateDockerWatcher = asyncHandler(async (req, res) => {
     dockerStatsCron: dockerStatsCron,
   }).send(res);
 });
+
+export const getAllDevices = asyncHandler(async (req, res) => {
+  const devices = await DeviceRepo.findAll();
+  if (!devices) {
+    return new SuccessResponse('Get Devices successful', []).send(res);
+  }
+
+  new SuccessResponse('Get Devices successful', devices).send(res);
+});

--- a/server/src/routes/devices.ts
+++ b/server/src/routes/devices.ts
@@ -16,6 +16,7 @@ import {
   addDevice,
   addDeviceAuto,
   deleteDevice,
+  getAllDevices,
   getDevices,
   updateDockerWatcher,
 } from '../controllers/rest/devices/device';
@@ -104,6 +105,7 @@ router
   .get(getCheckDeviceDockerConnectionValidator, getCheckDeviceDockerConnection);
 
 router.route('/').put(addDeviceValidator, addDevice).get(getDevices);
+router.route('/all').get(getAllDevices);
 router.delete(`/:uuid`, deleteDeviceValidator, deleteDevice);
 router.get(`/:uuid/stats/:type/`, getDeviceStatsByDeviceUuidValidator, getDeviceStatsByDeviceUuid);
 router.get(`/:uuid/stat/:type/`, getDeviceStatByDeviceUuidValidator, getDeviceStatByDeviceUuid);


### PR DESCRIPTION
Added a new getAllDevices function in the server to fetch all devices and updated various client-side components to use this function instead of getDevices. This change ensures uniformity in device retrieval across the application.