### PR TITLE
[BUG] **Refactor quick action components to include icons**

### DIFF
--- a/client/src/components/ContainerComponents/ContainerQuickAction/ContainerQuickActionDropDown.tsx
+++ b/client/src/components/ContainerComponents/ContainerQuickAction/ContainerQuickActionDropDown.tsx
@@ -30,6 +30,7 @@ const ContainerQuickActionDropDown: React.FC<ServiceQuickActionProps> = (
       return { type: 'divider' };
     return {
       label: e.label,
+      icon: e.icon,
       key: `${index}`,
       children: e.children?.map((f, submenuIndex) => {
         return { label: f.label, key: `${index}-${submenuIndex}` };

--- a/client/src/components/ContainerComponents/ContainerQuickAction/ContainerQuickActionReference.tsx
+++ b/client/src/components/ContainerComponents/ContainerQuickAction/ContainerQuickActionReference.tsx
@@ -16,11 +16,12 @@ export enum ServiceQuickActionReferenceTypes {
   SUBMENU = 'submenu',
 }
 
-export type ServiceQuickActionReferenceType = {
+export type ContainerQuickActionReferenceType = {
   type: ServiceQuickActionReferenceTypes;
   action?: ServiceQuickActionReferenceActions | SsmContainer.Actions;
-  label?: React.JSX.Element;
-  children?: ServiceQuickActionReferenceType[];
+  label?: React.ReactNode;
+  icon?: React.ReactNode;
+  children?: ContainerQuickActionReferenceType[];
 };
 
 export enum ServiceQuickActionReferenceActions {
@@ -28,69 +29,48 @@ export enum ServiceQuickActionReferenceActions {
   LIVE_LOGS = 'logs',
 }
 
-const ContainerQuickActionReference: ServiceQuickActionReferenceType[] = [
+const ContainerQuickActionReference: ContainerQuickActionReferenceType[] = [
   {
     type: ServiceQuickActionReferenceTypes.ACTION,
     action: ServiceQuickActionReferenceActions.LIVE_LOGS,
-    label: (
-      <>
-        <Live24Filled /> Live Logs
-      </>
-    ),
+    icon: <Live24Filled />,
+    label: 'Live Logs',
   },
   {
     type: ServiceQuickActionReferenceTypes.ACTION,
     action: ServiceQuickActionReferenceActions.RENAME,
-    label: (
-      <>
-        <EditOutlined /> Rename
-      </>
-    ),
+    icon: <EditOutlined />,
+    label: 'Rename',
   },
   {
     type: ServiceQuickActionReferenceTypes.ACTION,
     action: SsmContainer.Actions.STOP,
-    label: (
-      <>
-        <StopOutlined /> Stop
-      </>
-    ),
+    icon: <StopOutlined />,
+    label: 'Stop',
   },
   {
     type: ServiceQuickActionReferenceTypes.ACTION,
     action: SsmContainer.Actions.START,
-    label: (
-      <>
-        <PlayCircleFilled /> Start
-      </>
-    ),
+    icon: <PlayCircleFilled />,
+    label: 'Start',
   },
   {
     type: ServiceQuickActionReferenceTypes.ACTION,
     action: SsmContainer.Actions.RESTART,
-    label: (
-      <>
-        <SwapOutlined /> Restart
-      </>
-    ),
+    icon: <SwapOutlined />,
+    label: 'Restart',
   },
   {
     type: ServiceQuickActionReferenceTypes.ACTION,
     action: SsmContainer.Actions.PAUSE,
-    label: (
-      <>
-        <PauseOutlined /> Pause
-      </>
-    ),
+    icon: <PauseOutlined />,
+    label: 'Pause',
   },
   {
     type: ServiceQuickActionReferenceTypes.ACTION,
     action: SsmContainer.Actions.KILL,
-    label: (
-      <>
-        <CloseCircleOutlined /> Kill
-      </>
-    ),
+    icon: <CloseCircleOutlined />,
+    label: 'Kill',
   },
 ];
 

--- a/client/src/components/DeviceComponents/DeviceQuickAction/DeviceQuickActionDropDown.tsx
+++ b/client/src/components/DeviceComponents/DeviceQuickAction/DeviceQuickActionDropDown.tsx
@@ -59,6 +59,7 @@ const DeviceQuickActionDropDown: React.FC<QuickActionProps> = (props) => {
     if (e.onAdvancedMenu && props.advancedMenu === true) {
       if (e.type === Types.DIVIDER) return { type: 'divider' };
       return {
+        icon: e.icon,
         label: e.label,
         key: `${index}`,
         children: e.children?.map((f, submenuIndex) => {
@@ -68,6 +69,7 @@ const DeviceQuickActionDropDown: React.FC<QuickActionProps> = (props) => {
     } else if (!e.onAdvancedMenu) {
       if (e.type === Types.DIVIDER) return { type: 'divider' };
       return {
+        icon: e.icon,
         label: e.label,
         key: `${index}`,
         children: e.children?.map((f, submenuIndex) => {

--- a/client/src/components/DeviceComponents/DeviceQuickAction/DeviceQuickActionReference.tsx
+++ b/client/src/components/DeviceComponents/DeviceQuickAction/DeviceQuickActionReference.tsx
@@ -23,9 +23,10 @@ export type QuickActionReferenceType = {
   type: Types;
   action?: string;
   playbookQuickRef?: string;
-  label?: React.JSX.Element;
+  label?: React.ReactNode;
   onAdvancedMenu: boolean;
   children?: QuickActionReferenceType[];
+  icon?: React.ReactNode;
 };
 
 export enum Actions {
@@ -36,31 +37,22 @@ export enum Actions {
 const DeviceQuickActionReference: QuickActionReferenceType[] = [
   {
     type: Types.PLAYBOOK_SELECTION,
-    label: (
-      <>
-        <PlayCircleOutlined /> Execute a playbook
-      </>
-    ),
+    icon: <PlayCircleOutlined />,
+    label: 'Execute a playbook',
     onAdvancedMenu: false,
   },
   {
     type: Types.PLAYBOOK,
     playbookQuickRef: 'reboot',
-    label: (
-      <>
-        <ReloadOutlined /> Reboot
-      </>
-    ),
+    icon: <ReloadOutlined />,
+    label: 'Reboot',
     onAdvancedMenu: false,
   },
   {
     type: Types.ACTION,
     action: Actions.CONNECT,
-    label: (
-      <>
-        <LoginOutlined /> Connect
-      </>
-    ),
+    icon: <LoginOutlined />,
+    label: 'Connect',
     onAdvancedMenu: false,
   },
   {
@@ -70,11 +62,8 @@ const DeviceQuickActionReference: QuickActionReferenceType[] = [
   {
     type: Types.PLAYBOOK,
     playbookQuickRef: 'ping',
-    label: (
-      <>
-        <ShakeOutlined /> Ping
-      </>
-    ),
+    icon: <ShakeOutlined />,
+    label: 'Ping',
     onAdvancedMenu: false,
   },
   {
@@ -85,41 +74,29 @@ const DeviceQuickActionReference: QuickActionReferenceType[] = [
     type: Types.PLAYBOOK,
     playbookQuickRef: 'updateAgent',
     onAdvancedMenu: true,
-    label: (
-      <>
-        <ToTopOutlined /> Update Agent
-      </>
-    ),
+    icon: <ToTopOutlined />,
+    label: 'Update Agent',
   },
   {
     type: Types.PLAYBOOK,
     playbookQuickRef: 'reinstallAgent',
     onAdvancedMenu: true,
-    label: (
-      <>
-        <DownloadOutlined /> Reinstall Agent
-      </>
-    ),
+    icon: <DownloadOutlined />,
+    label: 'Reinstall Agent',
   },
   {
     type: Types.PLAYBOOK,
     playbookQuickRef: 'restartAgent',
     onAdvancedMenu: true,
-    label: (
-      <>
-        <ThunderboltOutlined /> Restart Agent
-      </>
-    ),
+    icon: <ThunderboltOutlined />,
+    label: 'Restart Agent',
   },
   {
     type: Types.PLAYBOOK,
     onAdvancedMenu: true,
     playbookQuickRef: 'retrieveAgentLogs',
-    label: (
-      <>
-        <BugOutlined /> Retrieve Agent Logs
-      </>
-    ),
+    icon: <BugOutlined />,
+    label: 'Retrieve Agent Logs',
   },
   {
     onAdvancedMenu: true,
@@ -129,21 +106,15 @@ const DeviceQuickActionReference: QuickActionReferenceType[] = [
     type: Types.PLAYBOOK,
     playbookQuickRef: 'uninstallAgent',
     onAdvancedMenu: true,
-    label: (
-      <>
-        <DeleteOutlined /> Uninstall Agent
-      </>
-    ),
+    icon: <DeleteOutlined />,
+    label: 'Uninstall Agent',
   },
   {
     type: Types.ACTION,
     action: Actions.DELETE,
     onAdvancedMenu: true,
-    label: (
-      <>
-        <DeleteOutlined /> Delete device
-      </>
-    ),
+    icon: <DeleteOutlined />,
+    label: 'Delete device',
   },
 ];
 

--- a/client/src/pages/Automations/Automations.tsx
+++ b/client/src/pages/Automations/Automations.tsx
@@ -12,10 +12,10 @@ import {
   ProTable,
 } from '@ant-design/pro-components';
 import '@umijs/max';
-import { Tabs, TabsProps } from 'antd';
-import React, { useEffect, useState, useRef } from 'react';
-import { API } from 'ssm-shared-lib';
 import { history, useLocation } from '@umijs/max';
+import { TabsProps } from 'antd';
+import React, { useEffect, useRef, useState } from 'react';
+import { API } from 'ssm-shared-lib';
 
 const Automations: React.FC = () => {
   const [currentRow, setCurrentRow] = useState<API.Automation | undefined>();

--- a/client/src/pages/Automations/components/AutomationQuickAction.tsx
+++ b/client/src/pages/Automations/components/AutomationQuickAction.tsx
@@ -20,27 +20,18 @@ type AutomationQuickActionProps = {
 
 const items = [
   {
-    label: (
-      <>
-        <PlayCircleOutlined /> Execute
-      </>
-    ),
+    label: 'Execute',
+    icon: <PlayCircleOutlined />,
     key: '1',
   },
   {
-    label: (
-      <>
-        <UnorderedListOutlined /> Show execution logs
-      </>
-    ),
+    label: 'Show execution logs',
+    icon: <UnorderedListOutlined />,
     key: 2,
   },
   {
-    label: (
-      <>
-        <DeleteOutlined /> Delete
-      </>
-    ),
+    label: 'Delete',
+    icon: <DeleteOutlined />,
     key: '3',
   },
 ];


### PR DESCRIPTION
Simplified the label structure of quick actions by adding a separate icon property. This enhances readability and maintainability by separating the icon and label elements.

 Following Ant Design lib bump