### PR TITLE
[BUG] Update log path for container management

### DIFF
--- a/client/src/pages/Containers/components/containers/ContainerMetas.tsx
+++ b/client/src/pages/Containers/components/containers/ContainerMetas.tsx
@@ -48,7 +48,7 @@ const ContainerMetas = (props: ContainerMetasProps) => {
         ServiceQuickActionReferenceActions.LIVE_LOGS
       ) {
         history.push({
-          pathname: `/manage/services/logs/${props.selectedRecord?.id}`,
+          pathname: `/manage/containers/logs/${props.selectedRecord?.id}`,
         });
       }
       if (


### PR DESCRIPTION
Changed the URL path from '/manage/services/logs/' to '/manage/containers/logs/' in the ContainerMetas component. This ensures the log redirection points to the correct route for container logs.