### PR TITLE
[FEAT] Add container ports handling and display link in UI

### DIFF
--- a/client/src/pages/Containers/components/containers/ContainerMetas.tsx
+++ b/client/src/pages/Containers/components/containers/ContainerMetas.tsx
@@ -3,6 +3,7 @@ import ServiceQuickActionReference, {
   ServiceQuickActionReferenceActions,
   ServiceQuickActionReferenceTypes,
 } from '@/components/ContainerComponents/ContainerQuickAction/ContainerQuickActionReference';
+import { ExternalLink } from '@/components/Icons/CustomIcons';
 import ContainerAvatar from '@/pages/Containers/components/containers/ContainerAvatar';
 import ContainerStatProgress from '@/pages/Containers/components/containers/ContainerStatProgress';
 import InfoToolTipCard from '@/pages/Containers/components/containers/InfoToolTipCard';
@@ -183,6 +184,22 @@ const ContainerMetas = (props: ContainerMetasProps) => {
       cardActionProps: 'extra',
       search: false,
       render: (text, row) => [
+        <>
+          {row.ports && row.ports.length > 0 && (
+            <Tooltip
+              key={`url-${row.id}`}
+              title={`http://${row.device?.ip}:${row.ports[0].PublicPort}`}
+            >
+              <a
+                href={`http://${row.device?.ip}:${row.ports[0].PublicPort}`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <ExternalLink style={{ color: 'rgb(22, 104, 220)' }} />
+              </a>
+            </Tooltip>
+          )}
+        </>,
         <Tooltip
           key={`info-${row.id}`}
           color={'transparent'}

--- a/server/src/data/database/model/Container.ts
+++ b/server/src/data/database/model/Container.ts
@@ -20,6 +20,7 @@ export default interface Container {
   transformTags?: string;
   linkTemplate?: string;
   command?: string;
+  ports?: { IP: string; PrivatePort: number; PublicPort: number; Type: string }[];
   networkSettings?: {
     Networks: {
       [p: string]: {
@@ -126,6 +127,9 @@ const schema = new Schema<Container>(
       type: Object,
     },
     updateKind: {
+      type: Object,
+    },
+    ports: {
       type: Object,
     },
     customName: {

--- a/server/src/modules/docker/watchers/providers/docker/Docker.ts
+++ b/server/src/modules/docker/watchers/providers/docker/Docker.ts
@@ -469,6 +469,7 @@ export default class Docker extends DockerLogs {
         },
         command: container.Command,
         networkSettings: container.NetworkSettings,
+        ports: container.Ports,
         mounts: container.Mounts,
       });
     } catch (error: any) {

--- a/shared-lib/src/types/api.ts
+++ b/shared-lib/src/types/api.ts
@@ -588,6 +588,10 @@ export type ContainerInspectResult = {
   link?: string;
 }
 
+export type ContainerPort = {
+   IP: string; PrivatePort: number; PublicPort: number; Type: string;
+}
+
 export type Container = {
   device?: DeviceItem;
   id?: string;
@@ -599,6 +603,7 @@ export type Container = {
   image?: Image;
   updateKind?: ContainerUpdate;
   result?: ContainerInspectResult;
+  ports?: ContainerPort[];
 }
 
 


### PR DESCRIPTION
Enhanced the Docker module to parse and store container ports information. Updated the API types and database model to support ports. Modified the UI to display a link based on the container's public port.