### PR TITLE
[CHORE] Rename SSHType.Automatic to SSHType.PasswordLess

### DIFF
--- a/client/src/components/DeviceConfiguration/ssh/AuthenticationCard.tsx
+++ b/client/src/components/DeviceConfiguration/ssh/AuthenticationCard.tsx
@@ -23,7 +23,7 @@ export type AuthenticationCardProps = {
 const connectionTypes = [
   { value: SsmAnsible.SSHType.UserPassword.valueOf(), label: 'User/Password' },
   { value: SsmAnsible.SSHType.KeyBased.valueOf(), label: 'Keys' },
-  { value: SsmAnsible.SSHType.Automatic.valueOf(), label: 'Automatic' },
+  { value: SsmAnsible.SSHType.PasswordLess.valueOf(), label: 'PasswordLess' },
 ];
 
 const AuthenticationCard: React.FC<AuthenticationCardProps> = ({ formRef }) => (
@@ -69,10 +69,10 @@ const AuthenticationCard: React.FC<AuthenticationCardProps> = ({ formRef }) => (
                   if (
                     (!sshConnection ||
                       sshConnection === SsmAnsible.SSHConnection.PARAMIKO) &&
-                    value == SsmAnsible.SSHType.Automatic
+                    value == SsmAnsible.SSHType.PasswordLess
                   ) {
                     return Promise.reject(
-                      'You must use regular SSH for automatic authentication',
+                      'You must use regular SSH for passwordless authentication',
                     );
                   }
                   return Promise.resolve();
@@ -130,7 +130,7 @@ const AuthenticationCard: React.FC<AuthenticationCardProps> = ({ formRef }) => (
               </ProForm.Group>
             );
           }
-          if (authType === SsmAnsible.SSHType.Automatic.valueOf()) {
+          if (authType === SsmAnsible.SSHType.PasswordLess.valueOf()) {
             return (
               <ProForm.Group>
                 <ProFormText

--- a/server/src/controllers/rest/devices/check-connection.validator.ts
+++ b/server/src/controllers/rest/devices/check-connection.validator.ts
@@ -14,16 +14,16 @@ export const postCheckAnsibleConnectionValidator = [
     .withMessage('sshConnection in body is required')
     .isIn(Object.values(SsmAnsible.SSHConnection))
     .withMessage('sshConnection is not in enum value SSHConnection')
-    .if(body('authType').equals(SsmAnsible.SSHType.Automatic))
+    .if(body('authType').equals(SsmAnsible.SSHType.PasswordLess))
     .isIn([SsmAnsible.SSHConnection.BUILTIN])
-    .withMessage('sshConnection must be ssh with automatic authentication'),
+    .withMessage('sshConnection must be ssh with passwordless authentication'),
   body('authType')
     .exists()
     .withMessage('authType in body is required')
     .isIn([
       SsmAnsible.SSHType.UserPassword,
       SsmAnsible.SSHType.KeyBased,
-      SsmAnsible.SSHType.Automatic,
+      SsmAnsible.SSHType.PasswordLess,
     ])
     .withMessage('authType is not in enum value SSHType'),
   body('sshPort').exists().notEmpty().isNumeric().withMessage('sshPort is not a number'),
@@ -39,7 +39,7 @@ export const postCheckAnsibleConnectionValidator = [
     .notEmpty()
     .isString(),
   body('sshUser')
-    .if(body('authType').isIn([SsmAnsible.SSHType.UserPassword, SsmAnsible.SSHType.Automatic]))
+    .if(body('authType').isIn([SsmAnsible.SSHType.UserPassword, SsmAnsible.SSHType.PasswordLess]))
     .exists()
     .notEmpty()
     .isString(),
@@ -64,7 +64,7 @@ export const postCheckDockerConnectionValidator = [
     .isIn([
       SsmAnsible.SSHType.UserPassword,
       SsmAnsible.SSHType.KeyBased,
-      SsmAnsible.SSHType.Automatic,
+      SsmAnsible.SSHType.PasswordLess,
     ])
     .withMessage('authType is not in enum value SSHType'),
   body('sshPort').exists().notEmpty().isNumeric().withMessage('sshPort is not a number'),
@@ -74,7 +74,7 @@ export const postCheckDockerConnectionValidator = [
     .notEmpty()
     .isString(),
   body('sshUser')
-    .if(body('authType').isIn([SsmAnsible.SSHType.UserPassword, SsmAnsible.SSHType.Automatic]))
+    .if(body('authType').isIn([SsmAnsible.SSHType.UserPassword, SsmAnsible.SSHType.PasswordLess]))
     .exists()
     .notEmpty()
     .isString(),

--- a/server/src/controllers/rest/devices/device.validator.ts
+++ b/server/src/controllers/rest/devices/device.validator.ts
@@ -15,9 +15,9 @@ export const addDeviceValidator = [
     .isIn(Object.values(SsmAnsible.SSHType))
     .withMessage('authType is not in enum value SSHType'),
   body('sshConnection')
-    .if(body('authType').equals(SsmAnsible.SSHType.Automatic))
+    .if(body('authType').equals(SsmAnsible.SSHType.PasswordLess))
     .isIn([SsmAnsible.SSHConnection.BUILTIN, undefined])
-    .withMessage('sshConnection must be "ssh" for automatic authentication'),
+    .withMessage('sshConnection must be "ssh" for passwordless authentication'),
   body('sshPort').exists().notEmpty().isNumeric().withMessage('sshPort is not a number'),
   body('unManaged').optional().isBoolean().withMessage('unManaged is not a boolean'),
   body('masterNodeUrl')
@@ -31,7 +31,7 @@ export const addDeviceValidator = [
     .notEmpty()
     .isString(),
   body('sshUser')
-    .if(body('authType').isIn([SsmAnsible.SSHType.UserPassword, SsmAnsible.SSHType.Automatic]))
+    .if(body('authType').isIn([SsmAnsible.SSHType.UserPassword, SsmAnsible.SSHType.PasswordLess]))
     .exists()
     .notEmpty()
     .isString(),

--- a/server/src/controllers/rest/devices/deviceauth.validator.ts
+++ b/server/src/controllers/rest/devices/deviceauth.validator.ts
@@ -37,7 +37,7 @@ export const addOrUpdateDeviceAuthValidator = [
     .notEmpty()
     .isString(),
   body('sshUser')
-    .if(body('authType').isIn([SsmAnsible.SSHType.UserPassword, SsmAnsible.SSHType.Automatic]))
+    .if(body('authType').isIn([SsmAnsible.SSHType.UserPassword, SsmAnsible.SSHType.PasswordLess]))
     .exists()
     .notEmpty()
     .isString(),
@@ -52,9 +52,9 @@ export const addOrUpdateDeviceAuthValidator = [
     .isIn(Object.values(SsmAnsible.AnsibleBecomeMethod))
     .withMessage('becomeMethod is not supported'),
   body('sshConnection')
-    .if(body('authType').equals(SsmAnsible.SSHType.Automatic))
+    .if(body('authType').equals(SsmAnsible.SSHType.PasswordLess))
     .isIn([SsmAnsible.SSHConnection.BUILTIN, undefined])
-    .withMessage('sshConnection must be "ssh" for automatic authentication'),
+    .withMessage('sshConnection must be "ssh" for passwordless authentication'),
   validator,
 ];
 

--- a/server/src/helpers/ssh/SSHCredentialsHelper.ts
+++ b/server/src/helpers/ssh/SSHCredentialsHelper.ts
@@ -76,7 +76,7 @@ class SSHCredentialsHelper {
   ): Promise<ConnectConfig> {
     let sshCredentials: ConnectConfig = {};
     switch (authType) {
-      case SSHType.Automatic:
+      case SSHType.PasswordLess:
         sshCredentials = {
           username: sshUsername,
         };

--- a/server/src/modules/ansible/utils/InventoryTransformer.ts
+++ b/server/src/modules/ansible/utils/InventoryTransformer.ts
@@ -76,8 +76,8 @@ function getAuth(deviceAuth: Partial<DeviceAuth>): Auth {
     case SsmAnsible.SSHType.UserPassword:
       auth.ansible_ssh_pass = { __ansible_vault: deviceAuth.sshPwd };
       break;
-    case SsmAnsible.SSHType.Automatic:
-      // We don't need secrets for automatic authentication
+    case SsmAnsible.SSHType.PasswordLess:
+      // We don't need secrets for passwordless authentication
       break;
     default:
       throw new Error('Unknown device Auth type');
@@ -100,7 +100,7 @@ function getInventoryConnectionVars(deviceAuth: Partial<DeviceAuth>): Connection
   // See https://docs.ansible.com/ansible/latest/collections/ansible/builtin/paramiko_ssh_connection.html
   let connection = deviceAuth.sshConnection;
   if (!connection) {
-    if (deviceAuth.authType === SsmAnsible.SSHType.Automatic) {
+    if (deviceAuth.authType === SsmAnsible.SSHType.PasswordLess) {
       // Paramiko does not work without a password or key
       connection = SsmAnsible.SSHConnection.BUILTIN;
     } else {

--- a/server/src/tests/unit-tests/helpers/ssh/SSHCredentialsHelper.test.ts
+++ b/server/src/tests/unit-tests/helpers/ssh/SSHCredentialsHelper.test.ts
@@ -100,8 +100,8 @@ describe('SSHCredentialsHelper', () => {
     expect(vault.vaultDecrypt).toHaveBeenCalledTimes(1);
   });
 
-  test('should handle automatic SSHType for default Docker SSH', async () => {
-    deviceAuth.authType = SsmAnsible.SSHType.Automatic;
+  test('should handle passwordless SSHType for default Docker SSH', async () => {
+    deviceAuth.authType = SsmAnsible.SSHType.PasswordLess;
 
     const result = await SSHCredentialsHelper.getDockerSshConnectionOptions(device, deviceAuth);
 
@@ -186,7 +186,7 @@ describe('SSHCredentialsHelper', () => {
     expect(vault.vaultDecrypt).toHaveBeenCalledTimes(1);
   });
 
-  test('should handle automatic SSHType for custom Docker SSH', async () => {
+  test('should handle passwordless SSHType for custom Docker SSH', async () => {
     deviceAuth.authType = SsmAnsible.SSHType.UserPassword;
     deviceAuth.sshPwd = 'sshpwd';
     deviceAuth.customDockerSSH = true;

--- a/server/src/tests/unit-tests/helpers/ssh/SSHCredentialsHelper.test.ts
+++ b/server/src/tests/unit-tests/helpers/ssh/SSHCredentialsHelper.test.ts
@@ -190,7 +190,7 @@ describe('SSHCredentialsHelper', () => {
     deviceAuth.authType = SsmAnsible.SSHType.UserPassword;
     deviceAuth.sshPwd = 'sshpwd';
     deviceAuth.customDockerSSH = true;
-    deviceAuth.dockerCustomAuthType = SsmAnsible.SSHType.Automatic;
+    deviceAuth.dockerCustomAuthType = SsmAnsible.SSHType.PasswordLess;
     deviceAuth.dockerCustomSshUser = '$customUser';
 
     const result = await SSHCredentialsHelper.getDockerSshConnectionOptions(device, deviceAuth);

--- a/server/src/tests/unit-tests/modules/ansible/InventoryTransformer.test.ts
+++ b/server/src/tests/unit-tests/modules/ansible/InventoryTransformer.test.ts
@@ -299,7 +299,7 @@ describe('test InventoryTransformer', () => {
 
     const deviceAuth2 = {
       device: { uuid: '2234-5678-9106', ip: '192.168.1.5' },
-      authType: SsmAnsible.SSHType.Automatic,
+      authType: SsmAnsible.SSHType.PasswordLess,
       becomeMethod: 'sudo',
       becomePass: 'password2',
       sshUser: 'root',

--- a/server/src/tests/unit-tests/modules/ansible/InventoryTransformer.test.ts
+++ b/server/src/tests/unit-tests/modules/ansible/InventoryTransformer.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from 'vitest';
 import { SsmAnsible } from 'ssm-shared-lib';
+import { describe, expect, test } from 'vitest';
 import InventoryTransformer from '../../../../modules/ansible/utils/InventoryTransformer'; // replace with actual file path
 
 describe('test InventoryTransformer', () => {
@@ -69,10 +69,10 @@ describe('test InventoryTransformer', () => {
     expect(result).toEqual(expectedResult);
   });
 
-  test('inventoryBuilderForTargetAutomatic', () => {
+  test('inventoryBuilderForTargetPasswordless', () => {
     const deviceAuth = {
       device: { uuid: '1234-5678-9102', ip: '192.168.1.2' },
-      authType: SsmAnsible.SSHType.Automatic,
+      authType: SsmAnsible.SSHType.PasswordLess,
       becomeMethod: 'sudo',
       becomePass: 'qwerty',
       sshUser: 'admin',

--- a/shared-lib/src/enums/ansible.ts
+++ b/shared-lib/src/enums/ansible.ts
@@ -17,7 +17,7 @@ export enum DefaultSharedExtraVarsList {
 export enum SSHType {
   UserPassword = 'userPwd',
   KeyBased = 'keyBased',
-  Automatic = 'automatic',
+  PasswordLess = 'passwordLess',
 }
 
 export enum SSHConnection {


### PR DESCRIPTION
Updated the SSHType enumeration from "Automatic" to "PasswordLess" across controllers, validators, helpers, unit tests, and the client-side. This affects all references to ensure consistent handling of passwordless SSH authentication.