### PR TITLE
[BUGFIX] Append --vault-id to ansible runner command

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -46,4 +46,4 @@ jobs:
       run: npm test
     - name: Test Python
       working-directory: ./server
-      run: npm test:python
+      run: npm run test:python

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -44,3 +44,6 @@ jobs:
     - name: Test
       working-directory: ./server
       run: npm test
+    - name: Test Python
+      working-directory: ./server
+      run: npm test:python

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build-shared && npm run build && cross-env NODE_ENV=production node dist/index.js",
     "build": "tsc",
     "test": "vitest --disable-console-intercept --reporter=basic ",
-    "test:python:install": "pip install -r ./src/ansible/requirements.txt",
+    "test:python:install": "pip install -r ./src/ansible/requirements.txt --break-system-packages",
     "test:python": "npm run test:python:install && npm run test:python:run",
     "test:python:run": "cd ./src/ansible && python3 -m unittest discover -s . -p \"*.py\"",
     "coverage": "vitest run --coverage"

--- a/server/package.json
+++ b/server/package.json
@@ -8,6 +8,7 @@
     "start": "npm run build-shared && npm run build && cross-env NODE_ENV=production node dist/index.js",
     "build": "tsc",
     "test": "vitest --disable-console-intercept --reporter=basic ",
+    "test:python": "cd ./src/ansible && python3 -m unittest discover -s . -p \"*.py\"",
     "coverage": "vitest run --coverage"
   },
   "version": "0.1.21",

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,9 @@
     "start": "npm run build-shared && npm run build && cross-env NODE_ENV=production node dist/index.js",
     "build": "tsc",
     "test": "vitest --disable-console-intercept --reporter=basic ",
-    "test:python": "cd ./src/ansible && python3 -m unittest discover -s . -p \"*.py\"",
+    "test:python:install": "pip install -r ./src/ansible/requirements.txt",
+    "test:python": "npm run test:python:install && npm run test:python:run",
+    "test:python:run": "cd ./src/ansible && python3 -m unittest discover -s . -p \"*.py\"",
     "coverage": "vitest run --coverage"
   },
   "version": "0.1.21",

--- a/server/src/ansible/requirements.txt
+++ b/server/src/ansible/requirements.txt
@@ -1,0 +1,3 @@
+requests
+mock
+requests_unixsocket

--- a/server/src/ansible/requirements.txt
+++ b/server/src/ansible/requirements.txt
@@ -1,3 +1,4 @@
 requests
 mock
 requests_unixsocket
+ansible-runner

--- a/server/src/ansible/ssm-ansible-run.py
+++ b/server/src/ansible/ssm-ansible-run.py
@@ -103,6 +103,8 @@ def execute():
             runner_args['cmdline'] += ' --diff'
         else:
             runner_args['cmdline'] = '--diff'
+    if 'cmdline' in runner_args:
+      runner_args['cmdline'] += ' --vault-id ssm@ssm-ansible-vault-password-client.py'
 
     thread_obj, runner_obj = ansible_runner.run_async(**runner_args)
     sys.stdout.write(runner_obj.config.ident)

--- a/server/src/ansible/test_ssm_ansible_run.py
+++ b/server/src/ansible/test_ssm_ansible_run.py
@@ -1,0 +1,147 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import subprocess
+
+class TestSSMAnsibleRun(unittest.TestCase):
+
+  @patch('requests.post')
+  @patch('requests_unixsocket.Session.post')
+  def test_execute_with_check_and_diff(self, mock_unix_post, mock_post):
+
+    mock_post.return_value = MagicMock(status_code=200)
+    mock_unix_post.return_value = MagicMock(status_code=200)
+
+    test_args = [
+      'python3', 'ssm-ansible-run.py',
+      '--playbook', 'test_playbook.yml',
+      '--ident', 'test_uuid',
+      '--check', '--diff'
+    ]
+
+    result = subprocess.run(test_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    self.assertEqual(result.returncode, 0)
+    self.assertIn('test_uuid', result.stdout.decode())
+
+  @patch('requests.post')
+  @patch('requests_unixsocket.Session.post')
+  def test_execute_without_check_and_diff(self, mock_unix_post, mock_post):
+
+    mock_post.return_value = MagicMock(status_code=200)
+    mock_unix_post.return_value = MagicMock(status_code=200)
+
+    test_args = [
+      'python3', 'ssm-ansible-run.py',
+      '--playbook', 'test_playbook.yml',
+      '--ident', 'test_uuid'
+    ]
+
+    result = subprocess.run(test_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    self.assertEqual(result.returncode, 0)
+    self.assertIn('test_uuid', result.stdout.decode())
+
+  @patch('requests.post')
+  @patch('requests_unixsocket.Session.post')
+  def test_execute_with_extra_vars_and_host_pattern(self, mock_unix_post, mock_post):
+
+    mock_post.return_value = MagicMock(status_code=200)
+    mock_unix_post.return_value = MagicMock(status_code=200)
+
+    extra_vars_json = '{"var1": "value1", "var2": "value2"}'
+    test_args = [
+      'python3', 'ssm-ansible-run.py',
+      '--playbook', 'test_playbook.yml',
+      '--ident', 'test_uuid',
+      '--extra-vars', extra_vars_json,
+      '--host-pattern', 'test_host'
+    ]
+
+    result = subprocess.run(test_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    self.assertEqual(result.returncode, 0)
+    self.assertIn('test_uuid', result.stdout.decode())
+
+  @patch('requests.post')
+  @patch('requests_unixsocket.Session.post')
+  def test_execute_with_specific_host(self, mock_unix_post, mock_post):
+
+    mock_post.return_value = MagicMock(status_code=200)
+    mock_unix_post.return_value = MagicMock(status_code=200)
+
+    specific_host_json = '{"name": "test_host", "address": "127.0.0.1"}'  # Ensure specific host JSON is a proper string
+    test_args = [
+      'python3', 'ssm-ansible-run.py',
+      '--playbook', 'test_playbook.yml',
+      '--ident', 'test_uuid',
+      '--specific-host', specific_host_json
+    ]
+
+    result = subprocess.run(test_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    self.assertEqual(result.returncode, 0)
+    self.assertIn('test_uuid', result.stdout.decode())
+
+  @patch('requests.post')
+  @patch('requests_unixsocket.Session.post')
+  def test_execute_with_invalid_extra_vars(self, mock_unix_post, mock_post):
+
+    mock_post.return_value = MagicMock(status_code=200)
+    mock_unix_post.return_value = MagicMock(status_code=200)
+
+    invalid_extra_vars_json = "{invalid_json}"
+    test_args = [
+      'python3', 'ssm-ansible-run.py',
+      '--playbook', 'test_playbook.yml',
+      '--ident', 'test_uuid',
+      '--extra-vars', invalid_extra_vars_json
+    ]
+
+    result = subprocess.run(test_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn('Expecting property name enclosed in double quotes', result.stderr.decode())
+
+
+  @patch('requests.post')
+  @patch('requests_unixsocket.Session.post')
+  def test_execute_with_mixed_flags_and_options(self, mock_unix_post, mock_post):
+
+    mock_post.return_value = MagicMock(status_code=200)
+    mock_unix_post.return_value = MagicMock(status_code=200)
+
+    extra_vars_json = '{"var1": "value1", "var2": "value2"}'  # Correct JSON format
+    specific_host_json = '{"name": "test_host", "address": "127.0.0.1"}'  # Ensure it's a proper string
+    test_args = [
+      'python3', 'ssm-ansible-run.py',
+      '--playbook', 'test_playbook.yml',
+      '--ident', 'test_uuid',
+      '--extra-vars', extra_vars_json,
+      '--specific-host', specific_host_json,
+      '--check', '--diff'
+    ]
+
+    result = subprocess.run(test_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    self.assertEqual(result.returncode, 0)
+    self.assertIn('test_uuid', result.stdout.decode())
+
+  @patch('requests.post')
+  @patch('requests_unixsocket.Session.post')
+  def test_execute_without_required_arguments(self, mock_unix_post, mock_post):
+
+    mock_post.return_value = MagicMock(status_code=200)
+    mock_unix_post.return_value = MagicMock(status_code=200)
+
+    test_args = [
+      'python3', 'ssm-ansible-run.py'
+    ]
+
+    result = subprocess.run(test_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn('the following arguments are required: --playbook, --ident', result.stderr.decode())
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Add --vault-id ssm@ssm-ansible-vault-password-client.py to the command line arguments if 'cmdline' exists in runner_args. This ensures the vault ID is always passed for secure password management.