### PR TITLE
[TEST] Refactor package upgrade logic and add Molecule tests

### DIFF
--- a/server/src/ansible/00000000-0000-0000-0000-000000000000/device/_upgrade.yml
+++ b/server/src/ansible/00000000-0000-0000-0000-000000000000/device/_upgrade.yml
@@ -18,34 +18,6 @@
   become: true
 
   tasks:
-    - name: Perform a dist-upgrade.
-      ansible.builtin.package:
-        name: "*"
-        state: latest
-
-    - name: Check if a reboot is required (Debian-based systems).
-      ansible.builtin.stat:
-        path: /var/run/reboot-required
-        get_checksum: no
-      register: reboot_required_file
-      when: ansible_distribution in ["Debian", "Ubuntu"]
-
-    - name: Check if a reboot is required (CentOS/RHEL-based systems).
-      ansible.builtin.command: /usr/bin/needs-restarting -r
-      register: needs_restarting
-      failed_when: needs_restarting.rc not in [0,1,123]
-      changed_when: needs_restarting.rc == 1
-      when: ansible_distribution in ["CentOS", "RedHat"]
-
-    - name: Reboot the server (if required - Debian-based systems).
-      ansible.builtin.reboot:
-      when: reboot_required_file.stat.exists
-
-    - name: Reboot the server (if required - CentOS/RHEL-based systems).
-      ansible.builtin.reboot:
-      when: ansible_distribution in ["CentOS", "RedHat"] and needs_restarting.rc == 1
-
-    - name: Remove dependencies that are no longer required.
-      ansible.builtin.package:
-        autoremove: true
-      when: ansible_distribution in ["Debian", "Ubuntu", "CentOS", "RedHat"]
+    - name: Perform an upgrade.
+      include_role:
+        name: upgrade_host_package

--- a/server/src/ansible/00000000-0000-0000-0000-000000000000/device/roles/upgrade_host_package/debian.yml
+++ b/server/src/ansible/00000000-0000-0000-0000-000000000000/device/roles/upgrade_host_package/debian.yml
@@ -1,0 +1,21 @@
+---
+# tasks/debian.yml
+
+- name: Perform a dist-upgrade.
+  ansible.builtin.package:
+    name: "*"
+    state: latest
+
+- name: Check if a reboot is required.
+  ansible.builtin.stat:
+    path: /var/run/reboot-required
+    get_checksum: no
+  register: reboot_required_file
+
+- name: Reboot the server if required.
+  ansible.builtin.reboot:
+  when: reboot_required_file.stat.exists
+
+- name: Remove dependencies that are no longer required.
+  ansible.builtin.package:
+    autoremove: true

--- a/server/src/ansible/00000000-0000-0000-0000-000000000000/device/roles/upgrade_host_package/main.yml
+++ b/server/src/ansible/00000000-0000-0000-0000-000000000000/device/roles/upgrade_host_package/main.yml
@@ -1,0 +1,8 @@
+---
+# tasks/main.yml
+
+- include_tasks: debian.yml
+  when: ansible_distribution in ["Debian", "Ubuntu"]
+
+- include_tasks: rhel.yml
+  when: ansible_distribution in ["CentOS", "RedHat"]

--- a/server/src/ansible/00000000-0000-0000-0000-000000000000/device/roles/upgrade_host_package/rhel.yml
+++ b/server/src/ansible/00000000-0000-0000-0000-000000000000/device/roles/upgrade_host_package/rhel.yml
@@ -1,0 +1,21 @@
+---
+# tasks/rhel.yml
+
+- name: Perform a dist-upgrade.
+  ansible.builtin.package:
+    name: "*"
+    state: latest
+
+- name: Check if a reboot is required.
+  ansible.builtin.command: /usr/bin/needs-restarting -r
+  register: needs_restarting
+  failed_when: needs_restarting.rc not in [0,1,123]
+  changed_when: needs_restarting.rc == 1
+
+- name: Reboot the server if required.
+  ansible.builtin.reboot:
+  when: needs_restarting.rc == 1
+
+- name: Remove dependencies that are no longer required.
+  ansible.builtin.package:
+    autoremove: true

--- a/server/src/tests/molecule/default/run_all.yml
+++ b/server/src/tests/molecule/default/run_all.yml
@@ -68,3 +68,19 @@
         - name: Show stderr of "Install docker"
           debug:
             msg: "{{ result_install_docker.stderr }}"
+
+    - name: Run "Upgrade packages"
+      block:
+        - name: Run Molecule test for "upgrade-packages"
+          command: molecule test -s upgrade-packages
+          args:
+            chdir: ../../
+          register: result_upgrade_packages
+
+        - name: Show result of "Upgrade packages"
+          debug:
+            msg: "{{ result_upgrade_packages.stdout }}"
+      always:
+        - name: Show stderr of "Upgrade packages"
+          debug:
+            msg: "{{ result_upgrade_packages.stderr }}"

--- a/server/src/tests/molecule/upgrade-packages/Dockerfile.j2
+++ b/server/src/tests/molecule/upgrade-packages/Dockerfile.j2
@@ -1,0 +1,15 @@
+# Dockerfile.j2
+
+FROM {{ item.image }}
+
+# For Debian-based systems
+{% if item.image.startswith('debian') or item.image.startswith('ubuntu') %}
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip sshpass sudo
+{% endif %}
+
+# For RHEL-based systems
+{% if item.image.startswith('centos') or item.image.startswith('rhel') or item.image.startswith('rockylinux') %}
+RUN yum update -y && \
+    yum install -y python3 python3-pip sshpass sudo
+{% endif %}

--- a/server/src/tests/molecule/upgrade-packages/converge.yml
+++ b/server/src/tests/molecule/upgrade-packages/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: false
+
+- import_playbook: "../../../ansible/00000000-0000-0000-0000-000000000000/device/_upgrade.yml"
+

--- a/server/src/tests/molecule/upgrade-packages/molecule.yml
+++ b/server/src/tests/molecule/upgrade-packages/molecule.yml
@@ -1,0 +1,27 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+platforms:
+  - name: debian-latest
+    image: debian:latest
+    command: "sleep infinity"  # Keep container running for Molecule to work with
+  - name: rockylinux
+    image: rockylinux:9.3
+    command: "sleep infinity"  # Keep container running for Molecule to work with
+
+provisioner:
+  name: ansible
+  log: true
+
+scenario:
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/server/src/tests/molecule/upgrade-packages/molecule.yml
+++ b/server/src/tests/molecule/upgrade-packages/molecule.yml
@@ -19,6 +19,7 @@ provisioner:
 
 scenario:
   test_sequence:
+    - dependency
     - destroy
     - create
     - prepare

--- a/server/src/tests/molecule/upgrade-packages/requirements.yml
+++ b/server/src/tests/molecule/upgrade-packages/requirements.yml
@@ -1,0 +1,6 @@
+collections:
+  - name: community.docker
+    version: ">=3.10.2"
+  - name: community.general
+    version: ">=7.0.0"
+    source: https://galaxy.ansible.com

--- a/server/src/tests/molecule/upgrade-packages/verify.yml
+++ b/server/src/tests/molecule/upgrade-packages/verify.yml
@@ -1,0 +1,28 @@
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Ensure no packages are pending for upgrade (Debian-based)
+      ansible.builtin.command: apt list --upgradable
+      register: apt_upgrade_check
+      changed_when: false
+      failed_when: "apt_upgrade_check.stdout | trim != '' and not apt_upgrade_check.stdout is search('Listing...')"
+      when: ansible_os_family == "Debian"
+
+    - name: Ensure no packages are pending for upgrade (RHEL-based)
+      ansible.builtin.command: yum check-update
+      register: yum_upgrade_check
+      changed_when: false
+      failed_when: >
+        yum_upgrade_check.stdout is search('^([a-zA-Z0-9_.+-]+)\s+([0-9][a-zA-Z0-9_:\-\.\+~]*)[^\r\n]*')
+        and not (yum_upgrade_check.stdout | trim is search('Last metadata expiration'))
+      when: ansible_os_family == "RedHat"
+
+    - name: Debug the result (Debian-based)
+      ansible.builtin.debug:
+        msg: "APT check output: {{ apt_upgrade_check.stdout }}"
+      when: ansible_os_family == "Debian"
+
+    - name: Debug the result (RHEL-based)
+      ansible.builtin.debug:
+        msg: "YUM check output: {{ yum_upgrade_check.stdout }}"
+      when: ansible_os_family == "RedHat"


### PR DESCRIPTION
Refactor the package upgrade logic by moving distribution-specific tasks to roles. Introduce Molecule tests to ensure proper functionality across Debian and RHEL-based systems. This enhances maintainability and improves test coverage.