### PR TITLE
[BUG] Refactor StackBuilder to DockerComposeStackBuilder

### DIFF
--- a/client/src/components/ComposeEditor/DockerComposeStackBuilder.tsx
+++ b/client/src/components/ComposeEditor/DockerComposeStackBuilder.tsx
@@ -25,15 +25,17 @@ export interface StackBuilderProps {
     iconBackgroundColor: string;
   };
   setStackIcon: any;
+  onClickSaveStack: () => void;
 }
 
-const StackBuilder: React.FC<StackBuilderProps> = ({
+const DockerComposeStackBuilder: React.FC<StackBuilderProps> = ({
   elementTypes,
   formRef,
   currentStack,
   setCurrentStack,
   stackIcon,
   setStackIcon,
+  onClickSaveStack,
 }) => {
   const [currentElement, setCurrentElement] = useState<
     MenuElementType | undefined
@@ -79,6 +81,7 @@ const StackBuilder: React.FC<StackBuilderProps> = ({
             formRef={formRef}
             setStackIcon={setStackIcon}
             stackIcon={stackIcon}
+            onClickSaveStack={onClickSaveStack}
           />
         </Col>
         <Col span={8}>
@@ -94,4 +97,4 @@ const StackBuilder: React.FC<StackBuilderProps> = ({
   );
 };
 
-export default StackBuilder;
+export default DockerComposeStackBuilder;

--- a/client/src/components/ComposeEditor/StackPanel.tsx
+++ b/client/src/components/ComposeEditor/StackPanel.tsx
@@ -31,6 +31,7 @@ type StackPanelProps = {
     iconBackgroundColor: string;
   };
   setStackIcon: any;
+  onClickSaveStack: () => void;
 };
 
 const StackPanel: React.FC<StackPanelProps> = ({
@@ -41,6 +42,7 @@ const StackPanel: React.FC<StackPanelProps> = ({
   formRef,
   stackIcon,
   setStackIcon,
+  onClickSaveStack,
 }) => {
   return (
     <Card>
@@ -55,11 +57,7 @@ const StackPanel: React.FC<StackPanelProps> = ({
                 <Button key="reset" onClick={() => formRef?.resetFields()}>
                   Reset
                 </Button>
-                <Button
-                  type="primary"
-                  key="submit"
-                  onClick={() => formRef?.submit?.()}
-                >
+                <Button type="primary" key="submit" onClick={onClickSaveStack}>
                   Save
                 </Button>
               </Space>

--- a/client/src/pages/ComposeEditor/index.tsx
+++ b/client/src/pages/ComposeEditor/index.tsx
@@ -1,6 +1,6 @@
 import FloatingButtonsBar from '@/components/ComposeEditor/FloatingButtonsBar';
 import { MenuElements } from '@/components/ComposeEditor/Menu/MenuElements';
-import StackBuilder from '@/components/ComposeEditor/StackBuilder';
+import DockerComposeStackBuilder from '@/components/ComposeEditor/DockerComposeStackBuilder';
 import {
   StackIcon,
   StackIconSelector,
@@ -325,10 +325,32 @@ const ComposeEditor = () => {
             style={{ width: '300px' }} // Adjust the width as needed
             placeholder={'Your saved stacks'}
             onChange={handleOnSelectStack}
+            fieldProps={{
+              optionRender: (option) => (
+                <Space>
+                  <span role="img" aria-label={option.data.label as string}>
+                    <StackIcon
+                      stackIcon={{
+                        icon: option.data.icon,
+                        iconColor: option.data.iconColor,
+                        iconBackgroundColor: option.data.iconBackgroundColor,
+                      }}
+                    />
+                  </span>
+                  {option.data.label}
+                </Space>
+              ),
+            }}
             request={async () =>
               await getCustomStacks().then((response) => {
                 return response.data.map((e) => {
-                  return { label: e.name, value: e.uuid };
+                  return {
+                    label: e.name,
+                    value: e.uuid,
+                    icon: e.icon,
+                    iconColor: e.iconColor,
+                    iconBackgroundColor: e.iconBackgroundColor,
+                  };
                 });
               })
             }
@@ -410,13 +432,14 @@ const ComposeEditor = () => {
                 variants={switchVariants}
                 transition={{ duration: 0.5 }}
               >
-                <StackBuilder
+                <DockerComposeStackBuilder
                   elementTypes={MenuElements}
                   formRef={form}
                   setCurrentStack={setCurrentStack}
                   currentStack={currentStack}
                   stackIcon={stackIcon}
                   setStackIcon={setStackIcon}
+                  onClickSaveStack={saveStack}
                 />
               </motion.div>
             )}


### PR DESCRIPTION
Renamed StackBuilder component to DockerComposeStackBuilder for better clarity. Added `onClickSaveStack` prop and enhanced stack icon rendering, improving UI consistency and code readability.