### PR TITLE
[DOC] Add GitHub Actions workflow and update curl commands

### DIFF
--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -1,0 +1,23 @@
+on:
+  release:
+    types: [published]
+
+jobs:
+  github-releases-to-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Github Releases To Discord
+        uses: SethCohen/github-releases-to-discord@v1.15.1
+        with:
+          webhook_url: ${{ secrets.WEBHOOK_URL }}
+          color: "2105893"
+          username: "Release Changelog"
+          avatar_url: "https://cdn.discordapp.com/avatars/487431320314576937/bd64361e4ba6313d561d54e78c9e7171.png"
+          content: "||@everyone||"
+          footer_title: "Changelog"
+          footer_icon_url: "https://cdn.discordapp.com/avatars/487431320314576937/bd64361e4ba6313d561d54e78c9e7171.png"
+          footer_timestamp: true
+          max_description: '4096'
+          reduce_headings: true

--- a/site/docs/quickstart.md
+++ b/site/docs/quickstart.md
@@ -7,7 +7,7 @@ See [Requirements](/docs/requirements)
 ## Use the Script
 
 ```shell
-curl https://raw.githubusercontent.com/SquirrelCorporation/SquirrelServersManager/refs/heads/master/getSSM.sh | bash
+curl -sL https://getssm.io | bash 
 ```
 
 ## Use pre-built images

--- a/site/index.md
+++ b/site/index.md
@@ -67,7 +67,7 @@ features:
 
 ## Try it now!
 ```shell
-curl https://raw.githubusercontent.com/SquirrelCorporation/SquirrelServersManager/refs/heads/master/getSSM.sh | bash
+ curl -sL https://getssm.io | bash 
 ```
 --- 
 


### PR DESCRIPTION
Introduce a new GitHub Actions workflow to post release updates to Discord. Additionally, updated curl commands in documentation for better readability and simplicity.