### PR TITLE
[TEST] Add integration tests and mock strategy for Passport

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -87,6 +87,7 @@
         "globals": "^15.11.0",
         "mongodb-memory-server": "^10.1.2",
         "node-mocks-http": "^1.16.1",
+        "passport-mock-strategy": "^2.0.0",
         "prettier": "^3.3.3",
         "supertest": "^7.0.0",
         "ts-node": "^10.9.2",
@@ -5176,6 +5177,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -7800,6 +7808,62 @@
       "dependencies": {
         "jsonwebtoken": "^9.0.0",
         "passport-strategy": "^1.0.0"
+      }
+    },
+    "node_modules/passport-mock-strategy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-mock-strategy/-/passport-mock-strategy-2.0.0.tgz",
+      "integrity": "sha512-9YUT0sja/7n+HfQ+Jwx4XETERRh1uciRjpHhEZMcYS1FBnMrfrSlKVS42bMU06ewSFiPhXztazAE6XwiZdZQ/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "^4.16.1",
+        "@types/passport": "^1.0.0",
+        "es6-promise": "^4.2.6",
+        "passport": "^0.4.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/passport-mock-strategy/node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/passport-mock-strategy/node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/passport-mock-strategy/node_modules/passport": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
+      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/passport-strategy": {

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build-shared && npm run build && cross-env NODE_ENV=production node dist/index.js",
     "build": "tsc",
     "test": "vitest --disable-console-intercept --reporter=basic ",
-    "test:python:install": "pip install -r ./src/ansible/requirements.txt --break-system-packages",
+    "test:python:install": "PIP_BREAK_SYSTEM_PACKAGES=1 pip install -r ./src/ansible/requirements.txt",
     "test:python": "npm run test:python:install && npm run test:python:run",
     "test:python:run": "cd ./src/ansible && python3 -m unittest discover -s . -p \"*.py\"",
     "coverage": "vitest run --coverage"

--- a/server/package.json
+++ b/server/package.json
@@ -102,6 +102,7 @@
     "typescript": "^5.6.3",
     "vitest": "^2.1.3",
     "@types/js-yaml": "^4.0.9",
-    "@types/express": "^5.0.0"
+    "@types/express": "^5.0.0",
+    "passport-mock-strategy": "^2.0.0"
   }
 }

--- a/server/src/data/database/model/User.ts
+++ b/server/src/data/database/model/User.ts
@@ -4,7 +4,7 @@ import bcrypt from 'bcrypt';
 
 export const DOCUMENT_NAME = 'User';
 export const COLLECTION_NAME = 'users';
-export const SALT_ROUNDS = 8;
+const SALT_ROUNDS = 8;
 
 export enum Role {
   ADMIN = 'admin',

--- a/server/src/data/database/model/User.ts
+++ b/server/src/data/database/model/User.ts
@@ -4,7 +4,7 @@ import bcrypt from 'bcrypt';
 
 export const DOCUMENT_NAME = 'User';
 export const COLLECTION_NAME = 'users';
-const SALT_ROUNDS = 8;
+export const SALT_ROUNDS = 8;
 
 export enum Role {
   ADMIN = 'admin',

--- a/server/src/middlewares/Passport.ts
+++ b/server/src/middlewares/Passport.ts
@@ -2,11 +2,12 @@ import { Request } from 'express';
 import passport from 'passport';
 import passportJWT from 'passport-jwt';
 import passportBearer from 'passport-http-bearer';
+import MockStrategy from 'passport-mock-strategy';
 import { SECRET } from '../config';
 import UserRepo from '../data/database/repository/UserRepo';
 
-const JWTStrategy = passportJWT.Strategy;
-const BearerStrategy = passportBearer.Strategy;
+const JWTStrategy = process.env.NODE_ENV === 'test' ? MockStrategy : passportJWT.Strategy;
+const BearerStrategy = process.env.NODE_ENV === 'test' ? MockStrategy : passportBearer.Strategy;
 
 export const cookieExtractor = (req: Request) => {
   let jwt = null;
@@ -25,7 +26,6 @@ passport.use(
     },
     (jwtPayload, done) => {
       const { expiration } = jwtPayload;
-
       if (Date.now() > expiration) {
         done('Unauthorized', false);
       }

--- a/server/src/tests/integration-tests/test/controllers/rest/login.test.ts
+++ b/server/src/tests/integration-tests/test/controllers/rest/login.test.ts
@@ -1,0 +1,120 @@
+import bcrypt from 'bcrypt';
+import mongoose from 'mongoose';
+import request from 'supertest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SALT_ROUNDS, UsersModel } from '../../../../../data/database/model/User';
+import UserRepo from '../../../../../data/database/repository/UserRepo';
+import app from '../../server';
+
+describe('Auth Integration Tests', () => {
+  vi.mock('../../../data/database/repository/UserRepo', () => ({
+    findByEmailAndPassword: vi.fn(),
+  }));
+
+  beforeAll(async () => {
+    await mongoose.connect(process.env['MONGO_URI'] as string);
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+  });
+
+  afterEach(async () => {
+    await mongoose.connection.db?.dropDatabase();
+    vi.clearAllMocks();
+  });
+
+  beforeEach(async () => {
+    const user = new UsersModel({
+      email: 'test@example.com',
+      password: 'password',
+      role: 'admin',
+      avatar: 'test',
+      name: 'test',
+    });
+    await user.save();
+  });
+
+  describe('POST /login', () => {
+    it('should return 200 and set jwt cookie on successful login', async () => {
+      const response = await request(app)
+        .post('/users/login')
+        .send({ username: 'test@example.com', password: 'password' });
+
+      // Assertions
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(
+        expect.objectContaining({
+          message: 'Login success',
+          data: {
+            currentAuthority: 'admin',
+          },
+        }),
+      );
+      expect(response.headers['set-cookie']).toBeDefined();
+    });
+
+    it('should return 401 for invalid credentials', async () => {
+      const response = await request(app)
+        .post('/users/login')
+        .send({ username: 'invalid@example.com', password: 'wrongpassword' });
+
+      // Assertions
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual(
+        expect.objectContaining({
+          message: 'Identification is incorrect！',
+          success: false,
+        }),
+      );
+    });
+
+    it('should return 400 when email is incorrect', async () => {
+      const response = await request(app)
+        .post('/users/login')
+        .send({ username: 'invalid_example.com', password: 'password' });
+
+      // Assertions
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 400 when email is missing', async () => {
+      const response = await request(app).post('/users/login').send({ password: 'password' });
+
+      // Assertions
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 400 when password is missing', async () => {
+      const response = await request(app)
+        .post('/users/login')
+        .send({ username: 'test@example.com' });
+
+      // Assertions
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('POST /logout', () => {
+    it('should clear jwt cookie on successful logout', async () => {
+      const response = await request(app).post('/users/logout').set('Cookie', 'jwt=fake-jwt-token');
+
+      // Assertions
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(
+        expect.objectContaining({
+          message: 'Logout success',
+        }),
+      );
+      expect(response.headers['set-cookie']).toContainEqual(expect.stringContaining('jwt=;'));
+    });
+
+    it('should return 401 if no jwt token is found', async () => {
+      const response = await request(app).post('/users/logout');
+
+      // Assertions
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: 'Invalid jwt' });
+    });
+  });
+});

--- a/server/src/tests/integration-tests/test/controllers/rest/settings.test.ts
+++ b/server/src/tests/integration-tests/test/controllers/rest/settings.test.ts
@@ -1,0 +1,71 @@
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import app from '../../server';
+import UserRepo from '../../../../../data/database/repository/UserRepo';
+
+describe('User Controllers Integration Tests', () => {
+  beforeAll(async () => {
+    await mongoose.connect(process.env['MONGO_URI'] as string);
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+  });
+
+  beforeEach(() => {
+    vi.spyOn(UserRepo, 'findByEmail').mockResolvedValue({
+      email: 'test@example.com',
+      name: 'test',
+      avatar: 'test',
+      password: 'test',
+      role: 'test',
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks(); // Reset mocks after each test
+  });
+
+  describe('resetUserApiKey', () => {
+    it('should reset the user API key', async () => {
+      const mockUuid = 'new-unique-uuid';
+      const resetApiKeySpy = vi.spyOn(UserRepo, 'resetApiKey').mockResolvedValue(mockUuid);
+
+      const response = await request(app)
+        .post('/users/settings/resetApiKey')
+        .set('content-type', 'application/json');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        success: true,
+        message: 'Reset Api Key',
+        data: {
+          uuid: mockUuid,
+        },
+      });
+
+      expect(resetApiKeySpy).toHaveBeenCalledWith('test@example.com');
+    });
+  });
+
+  describe('setUserLoglevel', () => {
+    it('should set the user log level', async () => {
+      const userLogsLevel = { terminal: 5 };
+      const updateLogsLevelSpy = vi.spyOn(UserRepo, 'updateLogsLevel').mockResolvedValue();
+
+      const response = await request(app)
+        .post('/users/settings/logs')
+        .send(userLogsLevel)
+        .set('content-type', 'application/json');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        message: 'Set user log level',
+        success: true,
+      });
+
+      expect(updateLogsLevelSpy).toHaveBeenCalledWith('test@example.com', userLogsLevel);
+    });
+  });
+});

--- a/server/src/tests/integration-tests/test/controllers/rest/user.test.ts
+++ b/server/src/tests/integration-tests/test/controllers/rest/user.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { UsersModel } from '../../../../../data/database/model/User'; // Adjust the path to your User model
+import app from '../../server';
+
+const requestUserCreation = async (user: object) => {
+  try {
+    return await request(app)
+      .post('/users/create-first')
+      .send(user)
+      .set('content-type', 'application/json');
+  } catch (err: any) {
+    console.log(err);
+    // The error message we need is inside `err.response`
+    return err.response;
+  }
+};
+
+describe('User controller', () => {
+  beforeAll(async () => {
+    await mongoose.connect(process.env['MONGO_URI'] as string);
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+  });
+
+  beforeEach(async () => {
+    await mongoose.connection.db?.dropDatabase();
+  });
+
+  it('Has Users should be false if not user in db', async () => {
+    const response = await request(app)
+      .get('/users')
+      .set('content-type', 'application/json')
+      .send();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('message');
+    expect(response.body.data?.hasUsers).toBe(false);
+  });
+
+  it('Has Users should be true if a user is in db', async () => {
+    // Add a user to the database
+    const newUser = new UsersModel({
+      name: 'testuser',
+      email: 'testuser@example.com',
+      password: 'password123',
+      avatar: 'test',
+      role: 'admin',
+    });
+    await newUser.save();
+
+    const response = await request(app)
+      .get('/users')
+      .set('content-type', 'application/json')
+      .send();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('message');
+    expect(response.body.data?.hasUsers).toBe(true);
+  });
+
+  it('should create the first user when no users exist', async () => {
+    const user = {
+      email: 'test@example.com',
+      password: 'password123',
+      name: 'Test User',
+      avatar: '/avatars/test.svg',
+    };
+
+    const response = await request(app)
+      .post('/users')
+      .send(user)
+      .set('content-type', 'application/json');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('message', 'Create first user');
+
+    // Verify that the user is actually created in the DB
+    const createdUser = await UsersModel.findOne({ email: 'test@example.com' });
+    expect(createdUser).not.toBeNull();
+    expect(createdUser).toMatchObject({
+      email: 'test@example.com',
+      name: 'Test User',
+      avatar: '/avatars/test.svg',
+    });
+  });
+
+  it('should return an error if email is missing', async () => {
+    const user = {
+      password: 'password123',
+      name: 'Test User',
+      avatar: '/avatars/test.svg',
+    };
+
+    const response = await request(app)
+      .post('/users/create-first')
+      .send(user)
+      .set('content-type', 'application/json');
+    expect(response.status).toBe(401);
+  });
+
+  it('should return an error if password is missing', async () => {
+    const user = {
+      email: 'test@example.com',
+      name: 'Test User',
+      avatar: '/avatars/test.svg',
+    };
+
+    const response = await requestUserCreation(user);
+
+    expect(response.status).toBe(401);
+  });
+
+  it('should return an error if name is missing', async () => {
+    const user = {
+      email: 'test@example.com',
+      password: 'password123',
+      avatar: '/avatars/test.svg',
+    };
+
+    const response = await request(app)
+      .post('/users/create-first')
+      .send(user)
+      .set('content-type', 'application/json');
+
+    expect(response.status).toBe(401);
+  });
+
+  it('should return an error if email is not valid', async () => {
+    const user = {
+      email: 'notAnEmail',
+      password: 'password123',
+      name: 'Test User',
+      avatar: '/avatars/test.svg',
+    };
+
+    const response = await request(app)
+      .post('/users/create-first')
+      .send(user)
+      .set('content-type', 'application/json');
+
+    expect(response.status).toBe(401);
+  });
+
+  it('should return an error if avatar is not a string', async () => {
+    const user = {
+      email: 'test@example.com',
+      password: 'password123',
+      name: 'Test User',
+      avatar: 12345, // Invalid type for avatar
+    };
+
+    const response = await request(app)
+      .post('/users/create-first')
+      .send(user)
+      .set('content-type', 'application/json');
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/server/src/tests/integration-tests/test/ping.test.ts
+++ b/server/src/tests/integration-tests/test/ping.test.ts
@@ -1,8 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import mongoose from 'mongoose';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import request from 'supertest';
 import app from './server';
 
-describe('delete a task', () => {
+describe('Ping Basic test', () => {
+  beforeAll(async () => {
+    await mongoose.connect(process.env['MONGO_URI'] as string);
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+  });
+
   it('Ping', async () => {
     const response = await request(app).get('/ping').set('content-type', 'application/json').send();
     expect(response.status).toBe(200);

--- a/server/src/tests/integration-tests/vitest.config.mts
+++ b/server/src/tests/integration-tests/vitest.config.mts
@@ -5,7 +5,7 @@ export default defineConfig({
     setupFiles: './vitest.setup.ts',
     env: {
       SECRET: 'test',
-      NODE_ENV: 'test'
-    }
+      NODE_ENV: 'test',
+    },
   },
 });


### PR DESCRIPTION
This commit introduces integration tests for user-related controllers, including login, user creation, and settings management. It also adds the `passport-mock-strategy` package for testing environments and integrates it within the Passport configuration.