### PR TITLE
[BUG] Wrap playbook variable with single quotes in command

### DIFF
--- a/server/src/modules/ansible/AnsibleCmd.ts
+++ b/server/src/modules/ansible/AnsibleCmd.ts
@@ -52,7 +52,7 @@ class AnsibleCommandBuilder {
     const ident = `--ident '${uuid}'`;
     const dryRun = this.getDryRun(mode);
 
-    return `${AnsibleCommandBuilder.sudo} ${AnsibleCommandBuilder.ssmApiKeyEnv}=${user.apiKey} ${AnsibleCommandBuilder.ansibleConfigKeyEnv}=${ANSIBLE_CONFIG_FILE} ANSIBLE_FORCE_COLOR=1 ${AnsibleCommandBuilder.python} ${AnsibleCommandBuilder.ansibleRunner} --playbook ${playbook} ${ident} ${inventoryTargetsCmd} ${logLevel} ${dryRun} ${extraVarsCmd}`;
+    return `${AnsibleCommandBuilder.sudo} ${AnsibleCommandBuilder.ssmApiKeyEnv}=${user.apiKey} ${AnsibleCommandBuilder.ansibleConfigKeyEnv}=${ANSIBLE_CONFIG_FILE} ANSIBLE_FORCE_COLOR=1 ${AnsibleCommandBuilder.python} ${AnsibleCommandBuilder.ansibleRunner} --playbook '${playbook}' ${ident} ${inventoryTargetsCmd} ${logLevel} ${dryRun} ${extraVarsCmd}`;
   }
 }
 


### PR DESCRIPTION
This change ensures that the playbook path is correctly interpreted, especially if it contains spaces or special characters. It improves the robustness of the Ansible command execution in various environments.