### PR TITLE
[BUG] Add enhanced agent installation tests using Molecule

### DIFF
--- a/server/src/ansible/00000000-0000-0000-0000-000000000000/agent/roles/install_agent_node_v2/tasks/main.yml
+++ b/server/src/ansible/00000000-0000-0000-0000-000000000000/agent/roles/install_agent_node_v2/tasks/main.yml
@@ -1,13 +1,14 @@
 ---
 - name: Define variables
   set_fact:
-    base_path: {{ node_agent_base_path }}
-    nvm_dir:  {{ node_agent_nvm_dir }}
+    base_path: "{{ node_agent_base_path }}"
+    nvm_dir:  "{{ node_agent_nvm_dir }}"
     nvm_profile: "~/.bashrc"
     nvm_install: 'wget' # options are: wget, curl or git
     autocomplete: false
     nodejs_version: "lts"
     default: false
+    ansible_user: 'root'
 
 - include_tasks: debug.yml
 - include_tasks: error_handling.yml

--- a/server/src/tests/molecule/default/run_all.yml
+++ b/server/src/tests/molecule/default/run_all.yml
@@ -37,6 +37,22 @@
           debug:
             msg: "{{ result_install_agent.stderr }}"
 
+    - name: Run "Install agent enhanced"
+      block:
+        - name: Run Molecule test for "install-agent-enhanced"
+          command: molecule test -s install-agent-enhanced
+          args:
+            chdir: ../../
+          register: result_install_agent_enhanced
+
+        - name: Show result of "Install agent enhanced"
+          debug:
+            msg: "{{ result_install_agent_enhanced.stdout }}"
+      always:
+        - name: Show stderr of "Install agent enhanced"
+          debug:
+            msg: "{{ result_install_agent_enhanced.stderr }}"
+
     - name: Run "Create docker network"
       block:
         - name: Run Molecule test for "create-docker-network"

--- a/server/src/tests/molecule/install-agent-enhanced/converge.yml
+++ b/server/src/tests/molecule/install-agent-enhanced/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: instance
+  become: true
+  gather_facts: false
+
+- import_playbook: "../../../ansible/00000000-0000-0000-0000-000000000000/agent/_installAgent.yml"
+

--- a/server/src/tests/molecule/install-agent-enhanced/destroy.yml
+++ b/server/src/tests/molecule/install-agent-enhanced/destroy.yml
@@ -1,0 +1,10 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  tasks:
+    - name: Destroy docker container
+      community.docker.docker_container:
+        name: instance
+        state: absent

--- a/server/src/tests/molecule/install-agent-enhanced/molecule.yml
+++ b/server/src/tests/molecule/install-agent-enhanced/molecule.yml
@@ -1,0 +1,39 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: instance
+    image: python:3.11-bookworm
+
+scenario:
+  test_sequence:
+    - dependency
+    - destroy
+    - create
+    - prepare
+    - converge
+    # - idempotence
+    - verify
+
+provisioner:
+  name: ansible
+  inventory:
+    group_vars:
+      all:
+        _ssm_deviceId: 'device-id'
+        _ssm_masterNodeUrl: 'https://127.0.0.1'
+        _ssm_installMethod: 'node_enhanced_playbook'
+
+verifier:
+  name: ansible
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint

--- a/server/src/tests/molecule/install-agent-enhanced/prepare.yml
+++ b/server/src/tests/molecule/install-agent-enhanced/prepare.yml
@@ -1,0 +1,7 @@
+---
+- name: Prepare
+  hosts: instance
+  become: true
+  tasks:
+    - name: Ensure Python3 is installed
+      raw: test -e /usr/bin/python3 || (apt-get update && apt-get install -y python3 python3-pip)

--- a/server/src/tests/molecule/install-agent-enhanced/requirements.yml
+++ b/server/src/tests/molecule/install-agent-enhanced/requirements.yml
@@ -1,0 +1,6 @@
+collections:
+  - name: community.docker
+    version: ">=3.10.2"
+  - name: community.general
+    version: ">=7.0.0"
+    source: https://galaxy.ansible.com

--- a/server/src/tests/molecule/install-agent-enhanced/verify.yml
+++ b/server/src/tests/molecule/install-agent-enhanced/verify.yml
@@ -1,0 +1,87 @@
+---
+- name: Verify
+  hosts: instance
+  vars:
+    base_path: /opt/squirrelserversmanager
+    nvm_dir: "/root/.nvm"
+  tasks:
+    - name: Check node version
+      shell: . {{ nvm_dir }}/nvm.sh && node --version
+      register: node_version
+      args:
+        executable: /bin/bash
+
+    - name: Display Node.js version
+      debug:
+        msg: "Node.js version is {{ node_version.stdout }}"
+
+    - name: Check npm version
+      shell: . {{ nvm_dir }}/nvm.sh && npm --version
+      register: npm_version
+      args:
+        executable: /bin/bash
+
+    - name: Display NPM version
+      debug:
+        msg: "NPM version is {{ npm_version.stdout }}"
+
+    - name: Check PM2 is installed
+      shell: . {{ nvm_dir }}/nvm.sh && pm2 --version
+      register: pm2_version
+      args:
+        executable: /bin/bash
+
+    - name: Display PM2 version
+      debug:
+        msg: "PM2 version is {{ pm2_version.stdout }}"
+
+    - name: Check git is installed
+      shell: git --version
+      register: git_version
+      args:
+        executable: /bin/bash
+
+    - name: Display Git version
+      debug:
+        msg: "Git version is {{ git_version.stdout }}"
+
+    - name: Check API_URL_MASTER in .env file
+      shell: grep "API_URL_MASTER" /opt/squirrelserversmanager/.env
+      register: env_check
+
+    - name: Display .env content
+      debug:
+        msg: ".env file contains: {{ env_check.stdout }}"
+
+    - name: Assert API_URL_MASTER equals _ssm_masterNodeUrl
+      assert:
+        that:
+          - "'API_URL_MASTER={{ _ssm_masterNodeUrl }}' in env_check.stdout"
+          -
+    - name: Check hostid.txt file
+      shell: cat /opt/squirrelserversmanager/hostid.txt
+      register: hostid_check
+
+    - name: Display hostid.txt content
+      debug:
+        msg: "hostid.txt contents: {{ hostid_check.stdout }}"
+
+    - name: Assert hostid.txt content equals _ssm_deviceId
+      assert:
+        that:
+          - "hostid_check.stdout == '{{ _ssm_deviceId }}'"
+
+    - name: Check PM2 agent is running
+      shell: . {{ nvm_dir }}/nvm.sh && pm2 list
+      register: pm2_list
+      args:
+        executable: /bin/bash
+
+    - name: Display PM2 processes
+      debug:
+        msg: "PM2 processes: {{ pm2_list.stdout }}"
+
+    - name: Assert PM2 agent is running
+      assert:
+        that:
+          - "'agent' in pm2_list.stdout"


### PR DESCRIPTION
Introduced a new Molecule scenario called 'install-agent-enhanced' with playbooks for preparation, convergence, and verification. Updated the main Molecule run file to include these tests, verifying Node.js, npm, PM2, and git installations as well as specific environment configurations.