### PR TITLE
Add confirmation prompt for critical quick actions

### DIFF
--- a/client/src/components/DeviceComponents/DeviceQuickAction/DeviceQuickActionReference.tsx
+++ b/client/src/components/DeviceComponents/DeviceQuickAction/DeviceQuickActionReference.tsx
@@ -27,6 +27,7 @@ export type QuickActionReferenceType = {
   onAdvancedMenu: boolean;
   children?: QuickActionReferenceType[];
   icon?: React.ReactNode;
+  needConfirmation?: boolean;
 };
 
 export enum Actions {
@@ -47,6 +48,7 @@ const DeviceQuickActionReference: QuickActionReferenceType[] = [
     icon: <ReloadOutlined />,
     label: 'Reboot',
     onAdvancedMenu: false,
+    needConfirmation: true,
   },
   {
     type: Types.ACTION,


### PR DESCRIPTION
Introduced a needConfirmation flag in DeviceQuickActionReference to trigger confirmation prompts for critical actions like 'Reboot'. Integrated Popconfirm component in DeviceQuickActionDropDown to handle user confirmation before proceeding with these actions.