### PR TITLE
[BUG] Fix typo in CPU speed unit

### DIFF
--- a/client/src/pages/Dashboard/Components/CombinedPowerCard.tsx
+++ b/client/src/pages/Dashboard/Components/CombinedPowerCard.tsx
@@ -90,7 +90,7 @@ const CombinedPowerCard: React.FC = () => {
       }
       total={
         <Typography.Title level={3}>
-          {currentUser?.devices?.totalCpu?.toFixed(0)} GhZ /{' '}
+          {currentUser?.devices?.totalCpu?.toFixed(0)} GHz /{' '}
           {currentUser?.devices?.totalMem?.toFixed(0)} Gb
         </Typography.Title>
       }

--- a/client/src/pages/Devices/components/ListComponent.tsx
+++ b/client/src/pages/Devices/components/ListComponent.tsx
@@ -128,7 +128,7 @@ const ListContent: React.FC<API.DeviceItem> = React.memo((props) => {
       {props.status !== DeviceStatus.UNMANAGED && (
         <div className={styles.listContentItem} style={{ width: '80px' }}>
           <p style={{ minWidth: '80px' }}>
-            <WhhCpu /> {cpuSpeed} Ghz
+            <WhhCpu /> {cpuSpeed} GHz
           </p>
           <p style={{ minWidth: '80px' }}>
             <WhhRam /> {memSize} Gb


### PR DESCRIPTION
Corrected the unit for CPU speed from "Ghz" to "GHz" in both CombinedPowerCard and ListComponent to ensure consistency and accuracy. This change improves readability and maintains the standard notation for measuring CPU speed.