### PR TITLE
[CHORE] Remove unused imports and enable Ansible task profiling

### DIFF
--- a/server/src/ansible/default-ansible.cfg
+++ b/server/src/ansible/default-ansible.cfg
@@ -32,7 +32,7 @@
 # (integer) Expiration timeout for the cache plugin data
 ;fact_caching_timeout=86400
 # (list) List of enabled callbacks, not all callbacks need enabling, but many of those shipped with Ansible do as we don't want them activated by default.
-;callbacks_enabled=
+callbacks_enabled=profile_tasks
 # (string) When a collection is loaded that does not support the running Ansible version (with the collection metadata key `requires_ansible`).
 ;collections_on_ansible_version_mismatch=warning
 # (pathspec) Colon separated paths in which Ansible will search for collections content. Collections must be in nested *subdirectories*, not directly in these directories. For example, if ``COLLECTIONS_PATHS`` includes ``'{{ ANSIBLE_HOME ~ "/collections" }}'``, and you want to add ``my.collection`` to that directory, it must be saved as ``'{{ ANSIBLE_HOME} ~ "/collections/ansible_collections/my/collection" }}'``.

--- a/server/src/core/startup/index.ts
+++ b/server/src/core/startup/index.ts
@@ -1,10 +1,9 @@
-import { Repositories, SettingsKeys, SsmAnsible } from 'ssm-shared-lib';
+import { Repositories, SettingsKeys } from 'ssm-shared-lib';
 import { getFromCache, setToCache } from '../../data/cache';
 import initRedisValues from '../../data/cache/defaults';
 import { ContainerCustomStackModel } from '../../data/database/model/ContainerCustomStack';
 import { DeviceModel } from '../../data/database/model/Device';
 import { PlaybookModel } from '../../data/database/model/Playbook';
-import UserRepo from '../../data/database/repository/UserRepo';
 import { copyAnsibleCfgFileIfDoesntExist } from '../../helpers/ansible/AnsibleConfigurationHelper';
 import PinoLogger from '../../logger';
 import AutomationEngine from '../../modules/automations/AutomationEngine';


### PR DESCRIPTION
Removed unnecessary imports from the project, including `SsmAnsible` and `UserRepo`, to streamline the codebase. Enabled the `profile_tasks` callback in the Ansible configuration to support performance profiling.