### PR TITLE
[CHORE] Add unit tests for SshPrivateKeyFileManager

### DIFF
--- a/server/__mocks__/fs.cjs
+++ b/server/__mocks__/fs.cjs
@@ -1,0 +1,3 @@
+const { fs } = require('memfs');
+
+module.exports = fs;

--- a/server/__mocks__/fs/promises.cjs
+++ b/server/__mocks__/fs/promises.cjs
@@ -1,0 +1,3 @@
+const { fs } = require('memfs');
+
+module.exports = fs.promises;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -86,6 +86,7 @@
         "eslint-plugin-import-x": "^4.4.0",
         "eslint-plugin-prettier": "^5.2.1",
         "globals": "^15.12.0",
+        "memfs": "^4.14.0",
         "mongodb-memory-server": "^10.1.2",
         "node-mocks-http": "^1.16.1",
         "prettier": "^3.3.3",
@@ -2101,6 +2102,63 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsonjoy.com/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pack": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.1.0.tgz",
+      "integrity": "sha512-zlQONA+msXPPwHWZMKFVS78ewFczIll5lXiVPwFPCZUsrOKdxc2AvxU1HoNBmMRhqDZUR9HkC3UOm+6pME6Xsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "^1.1.1",
+        "@jsonjoy.com/util": "^1.1.2",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^1.20.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/util": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.5.0.tgz",
+      "integrity": "sha512-ojoNsrIuPI9g6o8UxhraZQSyF2ByJanAY4cTFbc8Mf2AXEF4aQRGY1dJxyJpuyav8r9FGflEt/Ff3u5Nt6YMPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -6429,6 +6487,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/hyperdyperid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
@@ -7029,6 +7097,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/memfs": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.14.0.tgz",
+      "integrity": "sha512-JUeY0F/fQZgIod31Ja1eJgiSxLn7BfQlCnqhwXFBzFHEw63OdLK7VJUJ7bnzNsWgCyoUP5tEp1VRY8rDaYzqOA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/json-pack": "^1.0.3",
+        "@jsonjoy.com/util": "^1.3.0",
+        "tree-dump": "^1.0.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
       }
     },
     "node_modules/memory-pager": {
@@ -9602,6 +9690,19 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "license": "MIT"
     },
+    "node_modules/thingies": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
+      "integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=10.18"
+      },
+      "peerDependencies": {
+        "tslib": "^2"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
@@ -9687,6 +9788,23 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/tree-dump": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.2.tgz",
+      "integrity": "sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/ts-api-utils": {

--- a/server/package.json
+++ b/server/package.json
@@ -103,6 +103,7 @@
     "typescript": "^5.6.3",
     "vitest": "^2.1.4",
     "@types/js-yaml": "^4.0.9",
-    "@types/express": "^5.0.0"
+    "@types/express": "^5.0.0",
+    "memfs": "^4.14.0"
   }
 }

--- a/server/src/tests/unit-tests/modules/shell/managers/SshPrivateKeyFileManager.test.ts
+++ b/server/src/tests/unit-tests/modules/shell/managers/SshPrivateKeyFileManager.test.ts
@@ -1,0 +1,175 @@
+import * as os from 'node:os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fs, vol } from 'memfs';
+import { DEFAULT_VAULT_ID, vaultDecrypt } from '../../../../../modules/ansible-vault/ansible-vault';
+import shellWrapper from '../../../../../modules/shell/ShellWrapper';
+import FileSystemManager from '../../../../../modules/shell/managers/FileSystemManager';
+import SshPrivateKeyFileManager from '../../../../../modules/shell/managers/SshPrivateKeyFileManager';
+
+// Mock necessary modules and methods
+vi.mock('node:fs');
+vi.mock('node:fs/promises');
+vi.mock('node:os');
+vi.mock('path');
+vi.mock('./../../../../modules/shell/ShellWrapper');
+vi.mock('../../../../../modules/shell/managers/FileSystemManager');
+vi.mock('../../../../../modules/ansible-vault/ansible-vault');
+
+describe('SshPrivateKeyFileManager', () => {
+  const execUuid = 'execUuid';
+  const deviceUuid = 'deviceUuid';
+  const sskVaultedKey = 'vaultedKey';
+  const decryptedContent = 'decryptedContent';
+
+  beforeEach(() => {
+    vol.reset(); // Reset memfs before each test
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getTmpKeyFileName', () => {
+    it('should generate the correct temporary key file name', () => {
+      const fileName = SshPrivateKeyFileManager.getTmpKeyFileName(execUuid, deviceUuid);
+      expect(fileName).toBe(`${execUuid}_${deviceUuid}`);
+    });
+  });
+
+  describe('getTmpKeyFilePath', () => {
+    it('should generate the correct temporary key file path', () => {
+      const tmpdir = '/tmp';
+      (os.tmpdir as any).mockReturnValue(tmpdir);
+      path.join = vi.fn((...args) => args.join('/'));
+
+      const fileName = `${execUuid}_${deviceUuid}`;
+      const filePath = SshPrivateKeyFileManager.getTmpKeyFilePath(fileName);
+
+      expect(filePath).toBe(`${tmpdir}/${fileName}_dec.key`);
+      expect(path.join).toHaveBeenCalledWith(tmpdir, `${fileName}_dec.key`);
+    });
+  });
+
+  describe('genAnsibleTemporaryPrivateKey', () => {
+    it('should create a temporary private key file and chmod it', async () => {
+      (vaultDecrypt as any).mockResolvedValue(decryptedContent);
+      vol.fromJSON(
+        {
+          './dir1/hw.txt': 'hello dir1',
+          './dir2/hw.txt': 'hello dir2',
+        },
+        // default cwd
+        '/tmp',
+      );
+      FileSystemManager.writeFile = vi.fn((content, filePath) => {
+        fs.writeFileSync(filePath, content); // Use memfs to simulate writing file
+      });
+      shellWrapper.chmod = vi.fn().mockReturnValue({ code: 0 });
+
+      const tmpKeyFilePath = await SshPrivateKeyFileManager.genAnsibleTemporaryPrivateKey(
+        sskVaultedKey,
+        deviceUuid,
+        execUuid,
+      );
+
+      expect(vaultDecrypt).toHaveBeenCalledWith(sskVaultedKey, DEFAULT_VAULT_ID);
+      expect(FileSystemManager.writeFile).toHaveBeenCalledWith(
+        decryptedContent as string,
+        tmpKeyFilePath,
+      );
+      expect(shellWrapper.chmod).toHaveBeenCalledWith('600', tmpKeyFilePath);
+      expect(fs.readFileSync(tmpKeyFilePath, 'utf8')).toBe(decryptedContent); // Verify file content in memfs
+      expect(tmpKeyFilePath).toBe(`${os.tmpdir()}/${execUuid}_${deviceUuid}_dec.key`);
+    });
+
+    it('should throw an error if chmod command fails', async () => {
+      (vaultDecrypt as any).mockResolvedValue(decryptedContent);
+      vol.fromJSON(
+        {
+          './dir1/hw.txt': 'hello dir1',
+          './dir2/hw.txt': 'hello dir2',
+        },
+        // default cwd
+        '/tmp',
+      );
+      FileSystemManager.writeFile = vi.fn((content, filePath) => {
+        fs.writeFileSync(filePath, content); // Use memfs to simulate writing file
+      });
+      shellWrapper.chmod = vi.fn().mockReturnValue({ code: 1 });
+
+      await expect(
+        SshPrivateKeyFileManager.genAnsibleTemporaryPrivateKey(sskVaultedKey, deviceUuid, execUuid),
+      ).rejects.toThrow(
+        `genAnsibleTemporaryPrivateKey - Error chmoding file ${os.tmpdir()}/${execUuid}_${deviceUuid}_dec.key`,
+      );
+    });
+  });
+
+  describe('removeAnsibleTemporaryPrivateKey', () => {
+    it('should remove the temporary key file if it exists', () => {
+      vol.fromJSON(
+        {
+          './dir1/hw.txt': 'hello dir1',
+          './dir2/hw.txt': 'hello dir2',
+        },
+        // default cwd
+        '/tmp',
+      );
+      const tmpKeyFilePath = `${os.tmpdir()}/${execUuid}_${deviceUuid}_dec.key`;
+      fs.writeFileSync(tmpKeyFilePath, ''); // Create an empty file in memfs
+
+      FileSystemManager.test = vi.fn((flag, filePath) => fs.existsSync(filePath));
+      FileSystemManager.deleteFile = vi.fn((filePath) => fs.unlinkSync(filePath));
+
+      SshPrivateKeyFileManager.removeAnsibleTemporaryPrivateKey(deviceUuid, execUuid);
+
+      expect(FileSystemManager.test).toHaveBeenCalledWith('-f', tmpKeyFilePath);
+      expect(FileSystemManager.deleteFile).toHaveBeenCalledWith(tmpKeyFilePath);
+      expect(fs.existsSync(tmpKeyFilePath)).toBe(false); // Verify file has been deleted in memfs
+    });
+
+    it('should warn if the temporary key file does not exist', () => {
+      const mockLogger = {
+        warn: vi.fn(),
+      };
+      (SshPrivateKeyFileManager as any).logger = mockLogger;
+
+      FileSystemManager.test = vi.fn().mockReturnValue(false);
+
+      SshPrivateKeyFileManager.removeAnsibleTemporaryPrivateKey(deviceUuid, execUuid);
+
+      const tmpKeyFilePath = `${os.tmpdir()}/${execUuid}_${deviceUuid}_dec.key`;
+
+      expect(FileSystemManager.test).toHaveBeenCalledWith('-f', tmpKeyFilePath);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        `remoteAnsibleTemporaryPrivateKey - File not found (${tmpKeyFilePath})`,
+      );
+    });
+  });
+
+  describe('removeAllAnsibleExecTemporaryPrivateKeys', () => {
+    it('should remove all temporary private keys for a specific execUuid', () => {
+      FileSystemManager.deleteFile = vi.fn();
+
+      const fileName = `${execUuid}_*`;
+      const tmpKeyFilePath = `${os.tmpdir()}/${fileName}_dec.key`;
+
+      SshPrivateKeyFileManager.removeAllAnsibleExecTemporaryPrivateKeys(execUuid);
+
+      expect(FileSystemManager.deleteFile).toHaveBeenCalledWith(tmpKeyFilePath);
+    });
+  });
+
+  describe('removeAllAnsibleTemporaryPrivateKeys', () => {
+    it('should remove all temporary private keys', () => {
+      FileSystemManager.deleteFile = vi.fn();
+
+      const tmpKeyFilePath = `${os.tmpdir()}/*_dec.key`;
+
+      SshPrivateKeyFileManager.removeAllAnsibleTemporaryPrivateKeys();
+
+      expect(FileSystemManager.deleteFile).toHaveBeenCalledWith(tmpKeyFilePath);
+    });
+  });
+});


### PR DESCRIPTION
Implemented extensive unit tests for SshPrivateKeyFileManager using vitest and memfs for mocking file system operations. Updated project dependencies to include memfs in package-lock.json and package.json.