### PR TITLE
[CHORE] Enable privilege escalation for device reboot task

### DIFF
--- a/server/src/ansible/00000000-0000-0000-0000-000000000000/device/_reboot.yml
+++ b/server/src/ansible/00000000-0000-0000-0000-000000000000/device/_reboot.yml
@@ -13,6 +13,7 @@
 # Tags: reboot, restart, host
 
 - hosts: all
+  become: true
   tasks:
   - name: Unconditionally reboot the machine
     ansible.builtin.reboot:


### PR DESCRIPTION
Added 'become: true' to the Ansible playbook to ensure the reboot task runs with the necessary privileges. This change is required for successful execution of the device reboot.