### PR TITLE
[CHORE] Add type exports and fix response types for connection checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,18 @@ curl https://raw.githubusercontent.com/SquirrelCorporation/SquirrelServersManage
 See [QuickStart](https://squirrelserversmanager.io/docs/quickstart)
 
 
-For the others methods, **Edit the `.env` file before anything.**
+For the others methods, **[Edit the `.env` file before anything](https://squirrelserversmanager.io/docs/quickstart#env-file).**
 
 ---
 
-## 🛳️ Production
+## 🛳️ Manual Install: Production
+Clone the project, [edit the `.env`](https://squirrelserversmanager.io/docs/quickstart#env-file) file and run:
 ```shell
 docker compose up
 ```
 
-## 🏗️ Development
+## 🏗️ Manual Install: Development
+Clone the project, [edit the `.env`](https://squirrelserversmanager.io/docs/quickstart#env-file) file and run:
 ```shell
 docker compose -f docker-compose.dev.yml up
 ```

--- a/client/src/components/NewDeviceModal/NewDeviceModal.tsx
+++ b/client/src/components/NewDeviceModal/NewDeviceModal.tsx
@@ -246,7 +246,7 @@ const NewDeviceModal: React.FC<NewDeviceModalProps> = (props) => {
                     label: 'Control Node URL',
                     placeholder: 'http://192.168.0.1',
                     rules: [{ required: true }],
-                    initialValue: currentUser?.settings.masterNodeUrl
+                    initialValue: currentUser?.settings?.masterNodeUrl
                       ? currentUser?.settings.masterNodeUrl
                       : `http://${document.location.hostname}:8000`,
                   },

--- a/server/src/controllers/rest/devices/check-connection.ts
+++ b/server/src/controllers/rest/devices/check-connection.ts
@@ -1,3 +1,4 @@
+import { API } from 'ssm-shared-lib';
 import DeviceAuthRepo from '../../../data/database/repository/DeviceAuthRepo';
 import DeviceRepo from '../../../data/database/repository/DeviceRepo';
 import { ForbiddenError, InternalError, NotFoundError } from '../../../middlewares/api/ApiError';
@@ -36,7 +37,9 @@ export const postCheckAnsibleConnection = async (req, res) => {
       becomePass,
       sshKeyPass,
     );
-    new SuccessResponse('Post CheckAnsibleConnection', { taskId: taskId }).send(res);
+    new SuccessResponse('Post CheckAnsibleConnection', {
+      taskId: taskId,
+    } as API.CheckAnsibleConnection).send(res);
   } catch (error: any) {
     throw new InternalError(error.message);
   }
@@ -63,7 +66,7 @@ export const postCheckDockerConnection = async (req, res) => {
     new SuccessResponse('Post CheckDockerConnection', {
       connectionStatus: result.status,
       errorMessage: result.message,
-    }).send(res);
+    } as API.CheckDockerConnection).send(res);
   } catch (error: any) {
     throw new InternalError(error.message);
   }
@@ -84,7 +87,7 @@ export const getCheckDeviceDockerConnection = async (req, res) => {
     new SuccessResponse('Post CheckDeviceDockerConnection', {
       connectionStatus: result.status,
       errorMessage: result.message,
-    }).send(res);
+    } as API.CheckDockerConnection).send(res);
   } catch (error: any) {
     throw new InternalError(error.message);
   }
@@ -105,7 +108,9 @@ export const getCheckDeviceAnsibleConnection = async (req, res) => {
   }
   try {
     const { taskId } = await DeviceUseCases.checkDeviceAnsibleConnection(req.user, device);
-    new SuccessResponse('Post CheckDeviceAnsibleConnection', { taskId: taskId }).send(res);
+    new SuccessResponse('Post CheckDeviceAnsibleConnection', {
+      taskId: taskId,
+    } as API.CheckAnsibleConnection).send(res);
   } catch (error: any) {
     throw new InternalError(error.message);
   }

--- a/shared-lib/src/types/api.ts
+++ b/shared-lib/src/types/api.ts
@@ -154,6 +154,15 @@ export type NewDevice = {
   success: boolean;
 };
 
+export type CheckAnsibleConnection = {
+  taskId: string;
+}
+
+export type CheckDockerConnection = {
+  connectionStatus: string;
+  errorMessage?: string;
+}
+
 export type VersionData = {
   kernel?: string;
   openssl?: string;


### PR DESCRIPTION
Added CheckAnsibleConnection and CheckDockerConnection types to api.ts and used these types in response objects for connection check responses. Updated README for better environment file instructions and fixed default URL initialization in NewDeviceModal.