### PR TITLE
[CHORE] Add timeout configuration for Docker API

### DIFF
--- a/server/src/services/DeviceUseCases.ts
+++ b/server/src/services/DeviceUseCases.ts
@@ -235,11 +235,12 @@ async function checkDockerConnection(
     );
     const agent = getCustomAgent(logger, {
       ...options.sshOptions,
+      timeout: 60000,
     });
     options.modem = new DockerModem({
       agent: agent,
     });
-    const dockerApi = new Dockerode(options);
+    const dockerApi = new Dockerode({ ...options, timeout: 60000 });
     await dockerApi.ping();
     await dockerApi.info();
     return {


### PR DESCRIPTION
A timeout of 60000ms has been added to both the custom agent and the Dockerode initialization. This ensures that requests to the Docker API have a defined limit, potentially avoiding indefinite hangs.