### PR TITLE
[CHORE] Prevent duplicate cache setting for masterNodeUrl

### DIFF
--- a/client/src/components/Template/Title.tsx
+++ b/client/src/components/Template/Title.tsx
@@ -21,6 +21,7 @@ export enum TitleColors {
   DEBUG = '#b614b6',
   ANSIBLE_CONF = '#c1660e',
   COMPOSE = '#8e7418',
+  HOST_URL = '#368e18',
 }
 
 export type PageContainerTitleProps = {

--- a/client/src/pages/Admin/Settings/components/AuthenticationSettings.tsx
+++ b/client/src/pages/Admin/Settings/components/AuthenticationSettings.tsx
@@ -1,5 +1,6 @@
-import { MynauiApi } from '@/components/Icons/CustomIcons';
+import { LinkAlt, MynauiApi } from '@/components/Icons/CustomIcons';
 import Title, { TitleColors } from '@/components/Template/Title';
+import { postMasterNodeUrlValue } from '@/services/rest/settings';
 import { postResetApiKey } from '@/services/rest/usersettings';
 import { useModel } from '@@/exports';
 import { InfoCircleFilled, WarningOutlined } from '@ant-design/icons';
@@ -14,13 +15,18 @@ import {
   Row,
   Col,
   Flex,
+  InputRef,
 } from 'antd';
 import React, { useState } from 'react';
 
 const AuthenticationSettings: React.FC = () => {
   const { initialState } = useModel('@@initialState');
+  const nodeUrlRef = React.useRef<InputRef | null>(null);
   const { currentUser } = initialState || {};
   const [apiKey, setApiKey] = useState(currentUser?.settings.apiKey);
+  const [masterNodeUrl, setMasterNodeUrl] = useState(
+    currentUser?.settings.masterNodeUrl,
+  );
 
   const onClickResetApiKey = async () => {
     await postResetApiKey().then((res) => {
@@ -29,8 +35,62 @@ const AuthenticationSettings: React.FC = () => {
     });
   };
 
+  const onClickUpdateSsmUrl = async () => {
+    await postMasterNodeUrlValue(
+      nodeUrlRef?.current?.input?.value as string,
+    ).then((res) => {
+      setMasterNodeUrl(res.data.value);
+      message.success({ content: 'SSM URL successfully saved', duration: 6 });
+    });
+  };
+
   return (
     <Card>
+      <Card
+        type="inner"
+        title={
+          <Title.SubTitle
+            title={'SSM URL'}
+            backgroundColor={TitleColors.HOST_URL}
+            icon={<LinkAlt />}
+          />
+        }
+        style={{ marginTop: 16 }}
+      >
+        <Flex vertical gap={32} style={{ width: '100%' }}>
+          <Row
+            justify="space-between"
+            align="middle"
+            gutter={[16, 16]}
+            style={{ width: '100%' }}
+          >
+            <Col xs={24} md={4}>
+              <Typography.Text>
+                <Popover
+                  content={
+                    'The SSM URL is used for programmatic access such as agent or direct REST API'
+                  }
+                >
+                  <InfoCircleFilled />
+                </Popover>{' '}
+                SSM URL
+              </Typography.Text>
+            </Col>
+            <Col xs={24} md={16}>
+              <Input
+                ref={nodeUrlRef}
+                defaultValue={masterNodeUrl}
+                style={{ width: '100%' }}
+              />
+            </Col>
+            <Col xs={24} md={4}>
+              <Button danger block onClick={onClickUpdateSsmUrl}>
+                Overwrite
+              </Button>
+            </Col>
+          </Row>
+        </Flex>
+      </Card>
       <Card
         type="inner"
         title={

--- a/client/src/services/rest/settings.ts
+++ b/client/src/services/rest/settings.ts
@@ -124,3 +124,15 @@ export async function postDeviceStatsSettings(
     ...(options || {}),
   });
 }
+
+export async function postMasterNodeUrlValue(
+  value: string,
+  options?: Record<string, any>,
+) {
+  return request<API.SimpleResult>(`/api/settings/keys/master-node-url`, {
+    method: 'POST',
+    ...{},
+    data: { value: value },
+    ...(options || {}),
+  });
+}

--- a/server/src/controllers/rest/settings/keys.ts
+++ b/server/src/controllers/rest/settings/keys.ts
@@ -1,0 +1,11 @@
+import { SsmAnsible } from 'ssm-shared-lib';
+import { setToCache } from '../../../data/cache';
+import { SuccessResponse } from '../../../middlewares/api/ApiResponse';
+
+export const postMasterNodeUrlValue = async (req, res) => {
+  const { value } = req.body;
+  await setToCache(SsmAnsible.DefaultSharedExtraVarsList.MASTER_NODE_URL, value);
+  new SuccessResponse('Set master node url value', {
+    value,
+  }).send(res);
+};

--- a/server/src/controllers/rest/settings/keys.validator.ts
+++ b/server/src/controllers/rest/settings/keys.validator.ts
@@ -1,0 +1,4 @@
+import { body } from 'express-validator';
+import validator from '../../../middlewares/Validator';
+
+export const postMasterNodeUrlValueValidator = [body('value').exists().isString(), validator];

--- a/server/src/core/startup/index.ts
+++ b/server/src/core/startup/index.ts
@@ -60,7 +60,10 @@ class Startup {
     await PlaybooksRepositoryEngine.syncAllRegistered();
     this.registerPersistedProviders();
     copyAnsibleCfgFileIfDoesntExist();
-    await setToCache('_ssm_masterNodeUrl', (await getFromCache('ansible-master-node-url')) || '');
+    const masterNodeUrl = await getFromCache('_ssm_masterNodeUrl');
+    if (!masterNodeUrl) {
+      await setToCache('_ssm_masterNodeUrl', (await getFromCache('ansible-master-node-url')) || '');
+    }
     await ContainerCustomStackModel.updateMany(
       { type: { $exists: false } },
       { $set: { type: Repositories.RepositoryType.LOCAL } },

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -16,6 +16,8 @@ import { postDevicesSettings } from '../controllers/rest/settings/devices';
 import { postDevicesSettingsValidator } from '../controllers/rest/settings/devices.validator';
 import { postDeviceStatsSettings } from '../controllers/rest/settings/devicestats';
 import { postDeviceStatsSettingsValidator } from '../controllers/rest/settings/devicestats.validator';
+import { postMasterNodeUrlValue } from '../controllers/rest/settings/keys';
+import { postMasterNodeUrlValueValidator } from '../controllers/rest/settings/keys.validator';
 import { postLogsSettings } from '../controllers/rest/settings/logs';
 import { postLogsSettingsValidator } from '../controllers/rest/settings/logs.validator';
 
@@ -27,6 +29,7 @@ router.post(`/dashboard/:key`, postDashboardSettingsValidator, postDashboardSett
 router.post(`/devices/:key`, postDevicesSettingsValidator, postDevicesSettings);
 router.post(`/logs/:key`, postLogsSettingsValidator, postLogsSettings);
 router.post(`/device-stats/:key`, postDeviceStatsSettingsValidator, postDeviceStatsSettings);
+router.post(`/keys/master-node-url`, postMasterNodeUrlValueValidator, postMasterNodeUrlValue);
 router.post(
   `/container-stats/:key`,
   postContainerStatsSettingsValidator,


### PR DESCRIPTION
This change modifies the startup process to check if '_ssm_masterNodeUrl' is already set in the cache before attempting to set it again. This prevents redundant operations and ensures the value is only set if it does not already exist.