### PR TITLE
[CHORE] Increase JSON request size limit to 50mb

### DIFF
--- a/server/src/App.ts
+++ b/server/src/App.ts
@@ -31,7 +31,7 @@ class AppWrapper extends EventManager {
         ...httpLoggerOptions,
       }),
     );
-    this.app.use(express.json());
+    this.app.use(express.json({ limit: '50mb' }));
     if (!SECRET) {
       throw new Error('No secret defined');
     }


### PR DESCRIPTION
This change updates the express.json middleware to accept payloads up to 50mb. This adjustment ensures that larger JSON data can be processed without errors. It is essential for handling extensive data input in requests.