### PR TITLE
[CHORE] Set default directory exclusions for tags

### DIFF
--- a/client/src/pages/Admin/Settings/components/subcomponents/forms/DirectoryExclusionForm.tsx
+++ b/client/src/pages/Admin/Settings/components/subcomponents/forms/DirectoryExclusionForm.tsx
@@ -11,7 +11,17 @@ const DirectoryExclusionForm: React.FC<DirectoryExclusionFormProps> = (
   props,
 ) => {
   const [tags, setTags] = useState(
-    props.selectedRecord?.directoryExclusionList || [],
+    props.selectedRecord?.directoryExclusionList || [
+      'production',
+      'staging',
+      'group_vars',
+      'host_vars',
+      'library',
+      'module_utils',
+      'filters_plugin',
+      'roles',
+      'inventories',
+    ],
   );
 
   const validateTag = (tag: string): boolean => {


### PR DESCRIPTION
Previously, the tags list did not include any default values. This update initializes the directoryExclusionList with common exclusion directories like 'production' and 'staging'. This helps ensure that these directories are excluded by default if no selections are made.