### PR TITLE
[CHORE] Add reload functionality after container actions

### DIFF
--- a/client/src/pages/Containers/components/Containers.tsx
+++ b/client/src/pages/Containers/components/Containers.tsx
@@ -122,6 +122,7 @@ const Containers: React.FC = () => {
           };
         }}
         metas={ContainerMetas({
+          reload: reload,
           selectedRecord: selectedRecord,
           setSelectedRecord: setSelectedRecord,
           setIsEditContainerCustomNameModalOpened:

--- a/client/src/pages/Containers/components/containers/ContainerMetas.tsx
+++ b/client/src/pages/Containers/components/containers/ContainerMetas.tsx
@@ -31,6 +31,7 @@ type ContainerMetasProps = {
   setIsEditContainerCustomNameModalOpened: React.Dispatch<
     React.SetStateAction<boolean>
   >;
+  reload: () => void;
 };
 const ContainerMetas = (props: ContainerMetasProps) => {
   const handleQuickAction = async (idx: number) => {
@@ -57,13 +58,19 @@ const ContainerMetas = (props: ContainerMetasProps) => {
           ServiceQuickActionReference[idx].action as SsmContainer.Actions,
         )
       ) {
+        message.loading({
+          content: `Container: ${ServiceQuickActionReference[idx].action} in progress... The page will be automatically refreshed.`,
+          duration: 6,
+        });
         await postContainerAction(
           props.selectedRecord?.id as string,
           ServiceQuickActionReference[idx].action as SsmContainer.Actions,
         ).then(() => {
-          message.info({
-            content: `Container : ${ServiceQuickActionReference[idx].action}`,
+          message.success({
+            content: `Container: ${ServiceQuickActionReference[idx].action}`,
+            duration: 6,
           });
+          return props.reload();
         });
       }
     }


### PR DESCRIPTION
Introduced a `reload` method to the `ContainerMetas` component, ensuring the page refreshes after container actions complete. Added user feedback messages to indicate that actions are in progress and have succeeded.