### PR TITLE
[CHORE] Update default cron interval for dockerWatcherCron

### DIFF
--- a/server/src/data/database/model/Device.ts
+++ b/server/src/data/database/model/Device.ts
@@ -68,7 +68,7 @@ const schema = new Schema<Device>(
     dockerWatcherCron: {
       type: Schema.Types.String,
       required: true,
-      default: '0 * * * *',
+      default: '0 */4 * * *',
     },
     dockerStatsCron: {
       type: Schema.Types.String,


### PR DESCRIPTION
Changed the default cron schedule for dockerWatcherCron from hourly to every 4 hours. This ensures reduced frequency for better performance and resource optimization while maintaining functionality.