### PR TITLE
[CHORE] Add environment variables for service names and use envsubst

### DIFF
--- a/docker-compose.demo.dev.yml
+++ b/docker-compose.demo.dev.yml
@@ -8,6 +8,9 @@ services:
     depends_on:
       - client
       - server
+    environment:
+      SERVER_NAME: server  # The Docker service name for the server
+      CLIENT_NAME: client  # The Docker service name for the client
   server:
     restart: unless-stopped
     build:

--- a/docker-compose.demo.prod.yml
+++ b/docker-compose.demo.prod.yml
@@ -7,6 +7,9 @@ services:
     depends_on:
       - client
       - server
+    environment:
+      SERVER_NAME: server  # The Docker service name for the server
+      CLIENT_NAME: client  # The Docker service name for the client
   server:
     restart: unless-stopped
     image: "ghcr.io/squirrelcorporation/squirrelserversmanager-server-demo:master"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,6 +13,9 @@ services:
     labels:
       wud.display.name: "SSM - Proxy"
       wud.watch.digest: false
+    environment:
+      SERVER_NAME: server  # The Docker service name for the server
+      CLIENT_NAME: client  # The Docker service name for the client
   mongo:
     env_file:
       - ./.env.dev

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,6 +13,9 @@ services:
     labels:
       wud.display.name: "SSM - Proxy"
       wud.watch.digest: false
+    environment:
+      SERVER_NAME: server  # The Docker service name for the server
+      CLIENT_NAME: client  # The Docker service name for the client
   mongo:
     container_name: mongo-ssm
     image: mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
     labels:
       wud.display.name: "SSM - Proxy"
       wud.watch.digest: false
+    environment:
+      SERVER_NAME: server  # The Docker service name for the server
+      CLIENT_NAME: client  # The Docker service name for the client
   mongo:
     container_name: mongo-ssm
     image: mongo

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -3,5 +3,7 @@ LABEL org.opencontainers.image.source=https://github.com/SquirrelCorporation/Squ
 LABEL org.opencontainers.image.description="SSM Proxy"
 LABEL org.opencontainers.image.licenses="GNU AFFERO GENERAL PUBLIC LICENSE"
 
-COPY default.conf /etc/nginx/conf.d
+COPY default.conf /etc/nginx/templates/nginx.conf.template
 COPY www/index.html /usr/share/nginx/html/custom.html
+
+CMD ["sh", "-c", "envsubst < /etc/nginx/templates/nginx.conf.template > /etc/nginx/conf.d'"]

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -5,11 +5,11 @@ server {
   access_log off;
   error_log off;
 
- location /api/socket.io/ {
+  location /api/socket.io/ {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $host;
 
-      proxy_pass http://server:3000/socket.io/;
+      proxy_pass http://${SERVER_NAME}:3000/socket.io/;
 
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
@@ -17,12 +17,12 @@ server {
   }
 
   location /api/ {
-    proxy_pass http://server:3000/;
+    proxy_pass http://${SERVER_NAME}:3000/;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
   location / {
-    proxy_pass http://client:8000/;
+    proxy_pass http://${CLIENT_NAME}:8000/;
 
     # WebSocket support
     proxy_http_version 1.1;
@@ -35,5 +35,3 @@ server {
     }
   }
 }
-
-


### PR DESCRIPTION
Introduce `SERVER_NAME` and `CLIENT_NAME` environment variables to define service names across configurations for better flexibility and maintainability. Updated the NGINX configuration to use these variables via `envsubst` and modified the Dockerfile to support the templating approach. These adjustments standardize service name handling and improve deployment consistency.