### PR TITLE
[BUG] Refactor repository deletion to use deleteAllByRepository

### DIFF
--- a/server/src/data/database/repository/ContainerCustomStackRepo.ts
+++ b/server/src/data/database/repository/ContainerCustomStackRepo.ts
@@ -36,6 +36,14 @@ async function listAllByRepository(
     .exec();
 }
 
+async function deleteAllByRepository(
+  containerCustomStackRepository: ContainerCustomStackRepository,
+) {
+  await ContainerCustomStackModel.deleteMany({
+    containerCustomStackRepository: containerCustomStackRepository,
+  }).exec();
+}
+
 async function findOneByPath(path: string) {
   return await ContainerCustomStackModel.findOne({ path: path }).lean().exec();
 }
@@ -48,4 +56,5 @@ export default {
   findByUuid,
   listAllByRepository,
   findOneByPath,
+  deleteAllByRepository,
 };

--- a/server/src/data/database/repository/PlaybookRepo.ts
+++ b/server/src/data/database/repository/PlaybookRepo.ts
@@ -62,8 +62,8 @@ async function findOneByUniqueQuickReference(quickRef: string): Promise<Playbook
     .exec();
 }
 
-async function deleteByRepository(playbooksRepository: PlaybooksRepository): Promise<void> {
-  await PlaybookModel.deleteOne({ playbooksRepository: playbooksRepository }).exec();
+async function deleteAllByRepository(playbooksRepository: PlaybooksRepository): Promise<void> {
+  await PlaybookModel.deleteMany({ playbooksRepository: playbooksRepository }).exec();
 }
 
 export default {
@@ -77,5 +77,5 @@ export default {
   findOneByPath,
   findAllWithActiveRepositories,
   findOneByUniqueQuickReference,
-  deleteByRepository,
+  deleteAllByRepository,
 };

--- a/server/src/services/GitCustomStacksRepositoryUseCases.ts
+++ b/server/src/services/GitCustomStacksRepositoryUseCases.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { SsmGit } from 'ssm-shared-lib';
 import ContainerCustomStackRepository from '../data/database/model/ContainerCustomStackRepository';
+import ContainerCustomStackRepo from '../data/database/repository/ContainerCustomStackRepo';
 import ContainerCustomStackRepositoryRepo from '../data/database/repository/ContainerCustomStackRepositoryRepo';
 import { InternalError } from '../middlewares/api/ApiError';
 import ContainerCustomStacksRepositoryComponent from '../modules/repository/ContainerCustomStacksRepositoryComponent';
@@ -92,6 +93,7 @@ async function deleteRepository(repository: ContainerCustomStackRepository): Pro
   }
   const directory = repositoryComponent.getDirectory();
   await ContainerCustomStacksRepositoryEngine.deregisterRepository(repository.uuid);
+  await ContainerCustomStackRepo.deleteAllByRepository(repository);
   await ContainerCustomStackRepositoryRepo.deleteByUuid(repository.uuid);
   Shell.FileSystemManager.deleteFiles(directory);
 }

--- a/server/src/services/PlaybooksRepositoryUseCases.ts
+++ b/server/src/services/PlaybooksRepositoryUseCases.ts
@@ -1,4 +1,5 @@
 import { API } from 'ssm-shared-lib';
+import PlaybookRepo from '../data/database/repository/PlaybookRepo';
 import { ForbiddenError, InternalError } from '../middlewares/api/ApiError';
 import Playbook, { PlaybookModel } from '../data/database/model/Playbook';
 import PlaybooksRepository from '../data/database/model/PlaybooksRepository';
@@ -126,6 +127,7 @@ async function deleteRepository(repository: PlaybooksRepository): Promise<void> 
   const directory = playbooksRepositoryComponent.getDirectory();
   const rootPath = playbooksRepositoryComponent.rootPath;
   await PlaybooksRepositoryEngine.deregisterRepository(repository.uuid);
+  await PlaybookRepo.deleteAllByRepository(repository);
   await PlaybooksRepositoryRepo.deleteByUuid(repository.uuid);
   Shell.FileSystemManager.deleteFiles(directory, rootPath);
 }


### PR DESCRIPTION
Updated repository deletion logic to use `deleteAllByRepository` instead of individual delete calls for both Playbook and CustomStack repositories. This change ensures bulk deletions are handled efficiently and consistently across related modules. Adjusted all relevant services and repositories to reflect the updated method.