### PR TITLE
[FEAT] Add Gitea support and improve Git URL validation.

### DIFF
--- a/client/src/pages/Admin/Settings/components/subcomponents/forms/GitForm.tsx
+++ b/client/src/pages/Admin/Settings/components/subcomponents/forms/GitForm.tsx
@@ -4,6 +4,7 @@ import {
   ProFormSelect,
   ProFormText,
 } from '@ant-design/pro-components';
+import { message } from 'antd';
 import React from 'react';
 import { API, SsmGit } from 'ssm-shared-lib';
 
@@ -68,7 +69,23 @@ const GitForm: React.FC<GitFormProps> = ({ selectedRecord, repositories }) => (
       name={'remoteUrl'}
       label={'Remote Url'}
       initialValue={selectedRecord?.remoteUrl}
-      rules={[{ required: true }]}
+      rules={[
+        { required: true },
+        { type: 'url' },
+        { pattern: /https:\/\//, message: 'Please include https://' },
+      ]}
+      fieldProps={{
+        onBlur: (e) => {
+          const value = e.target.value;
+          const regex = /https?:\/\/[^@\n]+:[^@\n]+@/; // Matches user:password@ in URLs
+          if (regex.test(value)) {
+            void message.warning({
+              content:
+                'Remote URL contains a username or access token. Consider removing it for security.',
+            });
+          }
+        },
+      }}
     />
     <ProFormText
       width={'md'}

--- a/server/src/modules/repository/git-playbooks-repository/GitPlaybooksRepositoryComponent.ts
+++ b/server/src/modules/repository/git-playbooks-repository/GitPlaybooksRepositoryComponent.ts
@@ -60,6 +60,7 @@ class GitPlaybooksRepositoryComponent
   async clone(syncAfter = false) {
     this.childLogger.info('Clone starting...');
     try {
+      await GitPlaybooksRepositoryUseCases.resetRepositoryError(this.uuid);
       try {
         void Shell.FileSystemManager.createDirectory(this.directory, DIRECTORY_ROOT);
       } catch (error: any) {
@@ -101,6 +102,7 @@ class GitPlaybooksRepositoryComponent
 
   async commitAndSync() {
     try {
+      await GitPlaybooksRepositoryUseCases.resetRepositoryError(this.uuid);
       await commitAndSync({
         ...this.options,
         logger: {
@@ -134,6 +136,7 @@ class GitPlaybooksRepositoryComponent
 
   async forcePull() {
     try {
+      await GitPlaybooksRepositoryUseCases.resetRepositoryError(this.uuid);
       await forcePull({
         ...this.options,
         logger: {

--- a/shared-lib/src/enums/git.ts
+++ b/shared-lib/src/enums/git.ts
@@ -2,5 +2,6 @@ export enum Services {
   Github = 'github',
   GitLab = 'gitlab',
   Bitbucket = 'bitbucket',
-  AzureRepos = 'azure-repos'
+  AzureRepos = 'azure-repos',
+  Gitea = 'gitea'
 }


### PR DESCRIPTION
This commit introduces support for Gitea in credential handling and Git operations. It also enhances Git URL validation by adding rules for `https://` formatting and issuing warnings for insecure credentials in URLs. Additionally, it ensures repository errors are reset in various Git actions for better reliability.