### PR TITLE
[CHORE] Set NODE_ENV to production for build steps in workflows

### DIFF
--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -34,13 +34,13 @@ jobs:
       run: npm ci
     - name: Build
       working-directory: ./shared-lib
-      run: npm run build --if-present
+      run: NODE_ENV=production npm run build --if-present
     - name: Install
       working-directory: ./client
       run: npm ci
     - name: Build
       working-directory: ./client
-      run: npm run build --if-present
+      run: NODE_ENV=production npm run build --if-present
     - name: Test
       working-directory: ./client
       run: npm test

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -34,13 +34,13 @@ jobs:
       run: npm ci
     - name: Build
       working-directory: ./shared-lib
-      run: npm run build --if-present
+      run: NODE_ENV=production npm run build --if-present
     - name: Install
       working-directory: ./server
       run: npm ci
     - name: Build
       working-directory: ./server
-      run: npm run build --if-present
+      run: NODE_ENV=production npm run build --if-present
     - name: Test
       working-directory: ./server
       run: npm test


### PR DESCRIPTION
This ensures that builds for both the server and client use the production environment, aligning with best practices and preventing unintended behavior during builds. Updated scripts in GitHub Actions workflows for test-server and test-client.