### PR TITLE
[CHORE] Add sorting option and enhance Ansible playbook tasks

### DIFF
--- a/server/src/ansible/00000000-0000-0000-0000-000000000000/agent/_checkDeviceBeforeAdd.yml
+++ b/server/src/ansible/00000000-0000-0000-0000-000000000000/agent/_checkDeviceBeforeAdd.yml
@@ -21,3 +21,16 @@
     - name: Check that you can connect (GET) to the API and it returns a status 200
       ansible.builtin.uri:
         url: "{{ _ssm_masterNodeUrl }}/api/ping"
+- name: Test Sudo Working
+  hosts: all
+  tasks:
+    - become: true
+      command: id -u
+      register: id_output
+    - assert:
+        that: id_output.stdout == '0'
+- name: Task completion summary
+  hosts: all
+  tasks:
+    - debug:
+        msg: "Become completed with {{ id_output.stdout }}"

--- a/server/src/controllers/rest/logs/task.ts
+++ b/server/src/controllers/rest/logs/task.ts
@@ -48,7 +48,7 @@ export const getTaskEvents = async (req, res) => {
   if (!id) {
     throw new NotFoundError('No id');
   }
-  const events = await AnsibleLogsRepo.findAllByIdent(id);
+  const events = await AnsibleLogsRepo.findAllByIdent(id, 1);
 
   new SuccessResponse('Get task logs successful', events).send(res);
 };

--- a/server/src/data/database/repository/AnsibleLogsRepo.ts
+++ b/server/src/data/database/repository/AnsibleLogsRepo.ts
@@ -7,11 +7,11 @@ async function create(ansibleLog: AnsibleLog): Promise<AnsibleLog> {
 }
 
 async function findAllByIdent(ident: string, sortedBy: -1 | 1 = -1): Promise<AnsibleLog[] | null> {
-  return await AnsibleLogModel.find({ ident: ident }).sort({ createdAt: sortedBy }).lean().exec();
+  return await AnsibleLogModel.find({ ident: { $eq: ident } }).sort({ createdAt: sortedBy }).lean().exec();
 }
 
 async function deleteAllByIdent(ident: string) {
-  return await AnsibleLogModel.deleteMany({ ident: ident }).lean().exec();
+  return await AnsibleLogModel.deleteMany({ ident: { $eq: ident } }).lean().exec();
 }
 
 async function deleteAll(): Promise<void> {

--- a/server/src/data/database/repository/AnsibleLogsRepo.ts
+++ b/server/src/data/database/repository/AnsibleLogsRepo.ts
@@ -6,8 +6,8 @@ async function create(ansibleLog: AnsibleLog): Promise<AnsibleLog> {
   return created.toObject();
 }
 
-async function findAllByIdent(ident: string): Promise<AnsibleLog[] | null> {
-  return await AnsibleLogModel.find({ ident: ident }).sort({ createdAt: -1 }).lean().exec();
+async function findAllByIdent(ident: string, sortedBy: -1 | 1 = -1): Promise<AnsibleLog[] | null> {
+  return await AnsibleLogModel.find({ ident: ident }).sort({ createdAt: sortedBy }).lean().exec();
 }
 
 async function deleteAllByIdent(ident: string) {


### PR DESCRIPTION
Improve `findAllByIdent` to allow sorting order customization. Update task logs controller to use ascending sort order. Extend Ansible playbook with sudo test and task completion debug output.