### PR TITLE
[CHORE] Update dependencies: antd, rc-util, and @aws-sdk/client-ecr

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,7 +22,7 @@
         "@umijs/plugin-antd-dayjs": "^0.3.0",
         "@umijs/route-utils": "^4.0.1",
         "@xterm/addon-fit": "^0.10.0",
-        "antd": "^5.22.6",
+        "antd": "^5.22.7",
         "buffer": "^6.0.3",
         "classnames": "^2.5.1",
         "dayjs": "^1.11.13",
@@ -20095,9 +20095,9 @@
       }
     },
     "node_modules/antd": {
-      "version": "5.22.6",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-5.22.6.tgz",
-      "integrity": "sha512-ZYURSV3FR8qQgbfpa554thlO07L6PeHwhAM0wmxnobOBogND/HqSnTU+UZTqT2b2y9MxSfAIu5Xn1uEM9UpceQ==",
+      "version": "5.22.7",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.22.7.tgz",
+      "integrity": "sha512-koT5QMliDgXc21yNcs4Uyuq6TeB5AJbzGZ2qjNExzE7Tjr8yYIX6sJsQfunsEV80wC1mpF7m9ldKuNj+PafcFA==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^7.1.0",
@@ -20146,7 +20146,7 @@
         "rc-tree": "~5.10.1",
         "rc-tree-select": "~5.24.5",
         "rc-upload": "~4.8.1",
-        "rc-util": "^5.44.2",
+        "rc-util": "^5.44.3",
         "scroll-into-view-if-needed": "^3.1.0",
         "throttle-debounce": "^5.0.2"
       },
@@ -37691,9 +37691,9 @@
       }
     },
     "node_modules/rc-util": {
-      "version": "5.44.2",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.2.tgz",
-      "integrity": "sha512-uGSk3hpPBLa3/0QAcKhCjgl4SFnhQCJDLvvpoLdbR6KgDuXrujG+dQaUeUvBJr2ZWak1O/9n+cYbJiWmmk95EQ==",
+      "version": "5.44.3",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.3.tgz",
+      "integrity": "sha512-q6KCcOFk3rv/zD3MckhJteZxb0VjAIFuf622B7ElK4vfrZdAzs16XR5p3VTdy3+U5jfJU5ACz4QnhLSuAGe5dA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",

--- a/client/package.json
+++ b/client/package.json
@@ -56,7 +56,7 @@
     "@umijs/plugin-antd-dayjs": "^0.3.0",
     "@umijs/route-utils": "^4.0.1",
     "@xterm/addon-fit": "^0.10.0",
-    "antd": "^5.22.6",
+    "antd": "^5.22.7",
     "buffer": "^6.0.3",
     "classnames": "^2.5.1",
     "dayjs": "^1.11.13",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.26",
       "license": "AGPL-3.0 license",
       "dependencies": {
-        "@aws-sdk/client-ecr": "^3.718.0",
+        "@aws-sdk/client-ecr": "^3.719.0",
         "axios": "^1.7.9",
         "bcrypt": "^5.1.1",
         "connect-mongo": "^5.1.0",
@@ -297,9 +297,9 @@
       }
     },
     "node_modules/@aws-sdk/client-ecr": {
-      "version": "3.718.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.718.0.tgz",
-      "integrity": "sha512-bF9aqlAWimltuq7rZPMGP2qCLuy3i1EFCcGnsDfkd0U3SdLVgMc8d2p5qhpvYyAVHf8RvfkUn2Hedflgz9NRnw==",
+      "version": "3.719.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.719.0.tgz",
+      "integrity": "sha512-aEo9ZO2DxeHuA/TTwgKSF6r6F9aZMwPmwFHXHjLSyCMplKFWlltXO5+uJdQSHWRDCN0EQjpnpxC5suwpPLK2LQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
   "version": "0.1.26",
   "author": "Squirrel Team",
   "dependencies": {
-    "@aws-sdk/client-ecr": "^3.718.0",
+    "@aws-sdk/client-ecr": "^3.719.0",
     "axios": "^1.7.9",
     "bcrypt": "^5.1.1",
     "connect-mongo": "^5.1.0",


### PR DESCRIPTION
Upgraded `antd` to v5.22.7, `rc-util` to v5.44.3, and `@aws-sdk/client-ecr` to v3.719.0 in both `package.json` and `package-lock.json`. This ensures compatibility with latest features, bug fixes, and security improvements.