### PR TITLE
[CHORE] Refactor tests to use async methods consistently

### DIFF
--- a/server/src/tests/unit-tests/helpers/vault-crypto/vault.test.ts
+++ b/server/src/tests/unit-tests/helpers/vault-crypto/vault.test.ts
@@ -37,44 +37,44 @@ describe('Vault', () => {
   });
 
   describe('general', function () {
-    test('shall throw on wrong header', () => {
+    test('shall throw on wrong header', async () => {
       const v = new Vault({ password });
       const vault = '';
-      expect(v.decrypt(vault)).rejects.toThrow('Bad vault header');
+      await expect(v.decrypt(vault)).rejects.toThrow('Bad vault header');
     });
 
-    test('shall throw on wrong version', () => {
+    test('shall throw on wrong version', async () => {
       const v = new Vault({ password });
       const vault = '$ANSIBLE_VAULT;1.0;AES256\n6135643365643261';
-      expect(v.decrypt(vault)).rejects.toThrow('Bad vault header');
+      await expect(v.decrypt(vault)).rejects.toThrow('Bad vault header');
     });
 
-    test('shall throw on wrong cipher', () => {
+    test('shall throw on wrong cipher', async () => {
       const v = new Vault({ password });
       const vault = '$ANSIBLE_VAULT;1.0;AES128\n6135643365643261';
-      expect(v.decrypt(vault)).rejects.toThrow('Bad vault header');
+      await expect(v.decrypt(vault)).rejects.toThrow('Bad vault header');
     });
 
-    test('shall throw on missing content', () => {
+    test('shall throw on missing content', async () => {
       const v = new Vault({ password });
       const vault = '$ANSIBLE_VAULT;1.1;AES256\n';
-      expect(v.decrypt(vault)).rejects.toThrow('Invalid vault');
+      await expect(v.decrypt(vault)).rejects.toThrow('Invalid vault');
     });
 
-    test('shall throw on compromised integrity', () => {
+    test('shall throw on compromised integrity', async () => {
       const v = new Vault({ password });
-      expect(v.decrypt(vaultBadIntegrity)).rejects.toThrow('Integrity check failed');
+      await expect(v.decrypt(vaultBadIntegrity)).rejects.toThrow('Integrity check failed');
     });
 
-    test('shall throw on bad chars', () => {
+    test('shall throw on bad chars', async () => {
       const v = new Vault({ password });
-      expect(v.decrypt(vaultBadValues)).rejects.toThrow('Integrity check failed');
+      await expect(v.decrypt(vaultBadValues)).rejects.toThrow('Integrity check failed');
     });
 
-    test('shall throw on missing password', () => {
+    test('shall throw on missing password', async () => {
       // @ts-expect-error testing
       const v = new Vault({});
-      expect(v.encrypt('vault', DEFAULT_VAULT_ID)).rejects.toThrow('No password');
+      await expect(v.encrypt('vault', DEFAULT_VAULT_ID)).rejects.toThrow('No password');
     });
   });
 

--- a/server/src/tests/unit-tests/modules/docker/Registry.test.ts
+++ b/server/src/tests/unit-tests/modules/docker/Registry.test.ts
@@ -62,7 +62,7 @@ describe('testing Registry', () => {
     ).resolves.toStrictEqual(['v3', 'v2', 'v1']);
   });
 
-  test('getImageManifestDigest should return digest for application/vnd.docker.distribution.manifest.list.v2+json then application/vnd.docker.distribution.manifest.v2+json', () => {
+  test('getImageManifestDigest should return digest for application/vnd.docker.distribution.manifest.list.v2+json then application/vnd.docker.distribution.manifest.v2+json', async () => {
     const registryMocked = new Registry();
     registryMocked.childLogger = { debug: vi.fn(), info: vi.fn(), error: vi.fn(), warn: vi.fn() };
     // @ts-expect-error partial type
@@ -107,7 +107,7 @@ describe('testing Registry', () => {
       }
       throw new Error('Boom!');
     };
-    expect(
+    await expect(
       registryMocked.getImageManifestDigest({
         name: 'image',
         architecture: 'amd64',
@@ -127,7 +127,7 @@ describe('testing Registry', () => {
     });
   });
 
-  test('getImageManifestDigest should return digest for application/vnd.docker.distribution.manifest.list.v2+json then application/vnd.docker.container.image.v1+json', () => {
+  test('getImageManifestDigest should return digest for application/vnd.docker.distribution.manifest.list.v2+json then application/vnd.docker.container.image.v1+json', async () => {
     const registryMocked = new Registry();
     registryMocked.childLogger = { debug: vi.fn(), info: vi.fn(), error: vi.fn(), warn: vi.fn() };
     // @ts-expect-error partial type
@@ -164,7 +164,7 @@ describe('testing Registry', () => {
       }
       throw new Error('Boom!');
     };
-    expect(
+    await expect(
       registryMocked.getImageManifestDigest({
         name: 'image',
         architecture: 'amd64',
@@ -184,7 +184,7 @@ describe('testing Registry', () => {
     });
   });
 
-  test('getImageManifestDigest should return digest for application/vnd.docker.distribution.manifest.v2+json', () => {
+  test('getImageManifestDigest should return digest for application/vnd.docker.distribution.manifest.v2+json', async () => {
     const registryMocked = new Registry();
     registryMocked.childLogger = { debug: vi.fn(), info: vi.fn(), error: vi.fn(), warn: vi.fn() };
     // @ts-expect-error partial type
@@ -215,7 +215,7 @@ describe('testing Registry', () => {
       }
       throw new Error('Boom!');
     };
-    expect(
+    await expect(
       registryMocked.getImageManifestDigest({
         name: 'image',
         architecture: 'amd64',
@@ -235,7 +235,7 @@ describe('testing Registry', () => {
     });
   });
 
-  test('getImageManifestDigest should return digest for application/vnd.docker.container.image.v1+json', () => {
+  test('getImageManifestDigest should return digest for application/vnd.docker.container.image.v1+json', async () => {
     const registryMocked = new Registry();
     registryMocked.childLogger = { debug: vi.fn(), info: vi.fn(), error: vi.fn(), warn: vi.fn() };
     // @ts-expect-error partial type
@@ -262,7 +262,7 @@ describe('testing Registry', () => {
       }
       throw new Error('Boom!');
     };
-    expect(
+    await expect(
       registryMocked.getImageManifestDigest({
         name: 'image',
         architecture: 'amd64',
@@ -283,12 +283,12 @@ describe('testing Registry', () => {
     });
   });
 
-  test('getImageManifestDigest should throw when no digest found', () => {
+  test('getImageManifestDigest should throw when no digest found', async () => {
     const registryMocked = new Registry();
     registryMocked.childLogger = { debug: vi.fn(), info: vi.fn(), error: vi.fn(), warn: vi.fn() };
     // @ts-expect-error partial type
     registryMocked.callRegistry = async () => ({});
-    expect(
+    await expect(
       registryMocked.getImageManifestDigest({
         name: 'image',
         architecture: 'amd64',

--- a/server/src/tests/unit-tests/modules/remote-system-information/system-information/bluetooth/bluetooth.utils.test.ts
+++ b/server/src/tests/unit-tests/modules/remote-system-information/system-information/bluetooth/bluetooth.utils.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseBluetoothManufacturer,
+  parseBluetoothType,
+  parseDarwinBluetoothDevices,
+  parseLinuxBluetoothInfo,
+  parseWindowsBluetooth,
+} from '../../../../../../modules/remote-system-information/system-information/bluetooth/bluetooth.utils';
+
+describe('Bluetooth Utils', () => {
+  describe('parseBluetoothType', () => {
+    const testCases = [
+      { input: 'wireless keyboard', expected: 'Keyboard' },
+      { input: 'gaming mouse', expected: 'Mouse' },
+      { input: 'magic trackpad', expected: 'Trackpad' },
+      { input: 'bluetooth speaker', expected: 'Speaker' },
+      { input: 'wireless headset', expected: 'Headset' },
+      { input: 'iphone 12', expected: 'Phone' },
+      { input: 'macbook pro', expected: 'Computer' },
+      { input: 'imac 27', expected: 'Computer' },
+      { input: 'ipad pro', expected: 'Tablet' },
+      { input: 'apple watch', expected: 'Watch' },
+      { input: 'unknown device', expected: '' },
+    ];
+
+    testCases.forEach(({ input, expected }) => {
+      it(`should correctly parse "${input}" as "${expected}"`, () => {
+        expect(parseBluetoothType(input)).toBe(expected);
+      });
+    });
+  });
+
+  describe('parseBluetoothManufacturer', () => {
+    const testCases = [
+      { input: 'Apple Magic Mouse', expected: 'Apple' },
+      { input: 'iPad Pro', expected: 'Apple' },
+      { input: 'iMac 27', expected: 'Apple' },
+      { input: 'iPhone 12', expected: 'Apple' },
+      { input: 'Magic Mouse 2', expected: 'Apple' },
+      { input: 'Magic Trackpad', expected: 'Apple' },
+      { input: 'MacBook Pro', expected: 'Apple' },
+      { input: 'Logitech Mouse', expected: 'Logitech' },
+      { input: 'Unknown Device', expected: 'Unknown' },
+    ];
+
+    testCases.forEach(({ input, expected }) => {
+      it(`should correctly identify "${input}" as "${expected}"`, () => {
+        expect(parseBluetoothManufacturer(input)).toBe(expected);
+      });
+    });
+  });
+
+  describe('parseLinuxBluetoothInfo', () => {
+    it('should correctly parse Linux bluetooth device info', () => {
+      const lines = ['Name=Magic Mouse', 'Class=0x002540', 'Icon=input-mouse'];
+      const macAddr1 = '00:11:22:33:44:55';
+      const macAddr2 = 'AA:BB:CC:DD:EE:FF';
+
+      const result = parseLinuxBluetoothInfo(lines, macAddr1, macAddr2);
+
+      expect(result).toEqual({
+        device: null,
+        name: 'Magic Mouse',
+        manufacturer: null,
+        macDevice: macAddr1,
+        macHost: macAddr2,
+        batteryPercent: null,
+        type: 'Mouse',
+        connected: false,
+      });
+    });
+
+    it('should handle empty input', () => {
+      const result = parseLinuxBluetoothInfo([]);
+      expect(result.name).toBe('');
+      expect(result.type).toBe('');
+    });
+  });
+
+  describe('parseDarwinBluetoothDevices', () => {
+    it('should correctly parse Darwin bluetooth device info', () => {
+      const bluetoothObject = {
+        device_minorClassOfDevice_string: 'Mouse',
+        device_name: 'Magic Mouse 2',
+        device_services: 'Mouse Service',
+        device_manufacturer: 'Apple Inc.',
+        device_addr: 'AA-BB-CC-DD-EE-FF',
+        device_batteryPercent: 85,
+        device_isconnected: 'attrib_Yes',
+      };
+      const macAddr2 = '00:11:22:33:44:55';
+
+      const result = parseDarwinBluetoothDevices(bluetoothObject, macAddr2);
+
+      expect(result).toEqual({
+        device: 'Mouse Service',
+        name: 'Magic Mouse 2',
+        manufacturer: 'Apple Inc.',
+        macDevice: 'aa:bb:cc:dd:ee:ff',
+        macHost: macAddr2,
+        batteryPercent: 85,
+        type: 'Mouse',
+        connected: true,
+      });
+    });
+
+    it('should handle empty input', () => {
+      const result = parseDarwinBluetoothDevices({}, '');
+      expect(result.name).toBe('');
+      expect(result.connected).toBe(false);
+    });
+  });
+
+  describe('parseWindowsBluetooth', () => {
+    it('should correctly parse Windows bluetooth device info', () => {
+      const lines = ['Name: Magic Mouse', 'Manufacturer: Apple'];
+
+      const result = parseWindowsBluetooth(lines);
+
+      expect(result).toEqual({
+        device: null,
+        name: 'Magic Mouse',
+        manufacturer: 'Apple',
+        macDevice: null,
+        macHost: null,
+        batteryPercent: null,
+        type: 'Mouse',
+        connected: null,
+      });
+    });
+
+    it('should handle empty input', () => {
+      const result = parseWindowsBluetooth([]);
+      expect(result.name).toBe('');
+      expect(result.manufacturer).toBe('');
+    });
+  });
+});

--- a/server/src/tests/unit-tests/modules/remote-system-information/system-information/remoteos.utils.test.ts
+++ b/server/src/tests/unit-tests/modules/remote-system-information/system-information/remoteos.utils.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  cidrToNetmask,
+  getIPv6ScopeId,
+  netmaskToCidr,
+} from '../../../../../modules/remote-system-information/system-information/remoteos.utils';
+
+describe('Remote OS Utils', () => {
+  describe('netmaskToCidr', () => {
+    const testCases = [
+      { netmask: '255.255.255.0', expected: 24 },
+      { netmask: '255.255.255.255', expected: 32 },
+      { netmask: '255.255.0.0', expected: 16 },
+      { netmask: '255.0.0.0', expected: 8 },
+      { netmask: '255.255.255.252', expected: 30 },
+      { netmask: '255.255.255.248', expected: 29 },
+      { netmask: '255.255.254.0', expected: 23 },
+      { netmask: '255.255.252.0', expected: 22 },
+      { netmask: '0.0.0.0', expected: 0 },
+    ];
+
+    testCases.forEach(({ netmask, expected }) => {
+      it(`should convert ${netmask} to CIDR ${expected}`, () => {
+        expect(netmaskToCidr(netmask)).toBe(expected);
+      });
+    });
+  });
+
+  describe('cidrToNetmask', () => {
+    const testCases = [
+      { cidr: 24, expected: '255.255.255.0' },
+      { cidr: 32, expected: '255.255.255.255' },
+      { cidr: 16, expected: '255.255.0.0' },
+      { cidr: 8, expected: '255.0.0.0' },
+      { cidr: 30, expected: '255.255.255.252' },
+      { cidr: 29, expected: '255.255.255.248' },
+      { cidr: 23, expected: '255.255.254.0' },
+      { cidr: 22, expected: '255.255.252.0' },
+      { cidr: 0, expected: '0.0.0.0' },
+    ];
+
+    testCases.forEach(({ cidr, expected }) => {
+      it(`should convert CIDR ${cidr} to netmask ${expected}`, () => {
+        expect(cidrToNetmask(cidr)).toBe(expected);
+      });
+    });
+  });
+
+  describe('getIPv6ScopeId', () => {
+    it('should return correct scope ID for known interfaces', () => {
+      expect(getIPv6ScopeId('Ethernet')).toBe(3);
+      expect(getIPv6ScopeId('WiFi')).toBe(4);
+      expect(getIPv6ScopeId('Loopback')).toBe(1);
+    });
+
+    it('should return undefined for unknown interfaces', () => {
+      expect(getIPv6ScopeId('NonExistentInterface')).toBeUndefined();
+      expect(getIPv6ScopeId('')).toBeUndefined();
+    });
+
+    it('should be case sensitive for interface names', () => {
+      expect(getIPv6ScopeId('ethernet')).toBeUndefined();
+      expect(getIPv6ScopeId('WIFI')).toBeUndefined();
+    });
+  });
+});

--- a/server/src/tests/unit-tests/modules/remote-system-information/system-information/utils.test.ts
+++ b/server/src/tests/unit-tests/modules/remote-system-information/system-information/utils.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  cleanString,
+  getValue,
+  hex2bin,
+  isFunction,
+  plistParser,
+  promiseAll,
+  sanitizeShellString,
+  strIsNumeric,
+  toInt,
+} from '../../../../../modules/remote-system-information/system-information/utils';
+
+describe('Utils', () => {
+  describe('getValue', () => {
+    it('should extract value from lines with default separator', () => {
+      const lines = ['Name: Test', 'Version: 1.0', 'Description: Some text'];
+      expect(getValue(lines, 'Version')).toBe('1.0');
+    });
+
+    it('should handle custom separator', () => {
+      const lines = ['Name=Test', 'Version=1.0', 'Description=Some text'];
+      expect(getValue(lines, 'Version', '=')).toBe('1.0');
+    });
+
+    it('should handle trimmed option', () => {
+      const lines = ['Name:   Test   ', 'Version:   1.0   '];
+      expect(getValue(lines, 'Name', ':', true)).toBe('Test');
+    });
+
+    it('should handle lineMatch option', () => {
+      const lines = ['NameSpace: Test', 'Name: Actual'];
+      expect(getValue(lines, 'Name', ':', false, true)).toBe('Actual');
+    });
+
+    it('should return empty string when property not found', () => {
+      const lines = ['Name: Test'];
+      expect(getValue(lines, 'Version')).toBe('');
+    });
+  });
+
+  describe('hex2bin', () => {
+    it('should convert hex to binary string', () => {
+      expect(hex2bin('FF')).toBe('11111111');
+      expect(hex2bin('A5')).toBe('10100101');
+      expect(hex2bin('00')).toBe('00000000');
+    });
+  });
+
+  describe('cleanString', () => {
+    it('should remove "To Be Filled By O.E.M." text', () => {
+      expect(cleanString('To Be Filled By O.E.M.')).toBe('');
+      expect(cleanString('Model: To Be Filled By O.E.M.')).toBe('Model: ');
+    });
+
+    it('should not modify other strings', () => {
+      expect(cleanString('Normal text')).toBe('Normal text');
+    });
+  });
+
+  describe('toInt', () => {
+    it('should convert string to integer', () => {
+      expect(toInt('123')).toBe(123);
+      expect(toInt('-123')).toBe(-123);
+    });
+
+    it('should return 0 for invalid numbers', () => {
+      expect(toInt('abc')).toBe(0);
+      expect(toInt('')).toBe(0);
+    });
+  });
+
+  describe('isFunction', () => {
+    it('should identify functions correctly', () => {
+      expect(isFunction(() => {})).toBe(true);
+      expect(isFunction(function () {})).toBe(true);
+      expect(isFunction(new Function())).toBe(true);
+    });
+
+    it('should return false for non-functions', () => {
+      expect(isFunction({})).toBe(false);
+      expect(isFunction(42)).toBe(false);
+      expect(isFunction('string')).toBe(false);
+    });
+  });
+
+  describe('promiseAll', () => {
+    it('should handle successful promises', async () => {
+      const promises = [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)];
+
+      const result = await promiseAll(promises);
+      expect(result.results).toEqual([1, 2, 3]);
+      expect(result.errors).toEqual([null, null, null]);
+    });
+
+    it('should handle failed promises', async () => {
+      const error = new Error('Test error');
+      const promises = [Promise.resolve(1), Promise.reject(error), Promise.resolve(3)];
+
+      const result = await promiseAll(promises);
+      expect(result.results).toEqual([1, null, 3]);
+      expect(result.errors[1]).toBe(error);
+    });
+  });
+
+  describe('sanitizeShellString', () => {
+    it('should sanitize strings with default options', () => {
+      expect(sanitizeShellString('hello<>world')).toBe('helloworld');
+      expect(sanitizeShellString('test*?[]|')).toBe('test');
+      expect(sanitizeShellString('cmd && rm')).toBe('cmd  rm');
+    });
+
+    it('should handle strict mode', () => {
+      expect(sanitizeShellString('test (123)', true)).toBe('test123');
+      expect(sanitizeShellString('hello@world', true)).toBe('helloworld');
+      expect(sanitizeShellString('test {value}', true)).toBe('testvalue');
+    });
+
+    it('should handle empty or undefined input', () => {
+      expect(sanitizeShellString('')).toBe('');
+      expect(sanitizeShellString(undefined)).toBe('');
+    });
+  });
+
+  describe('plistParser', () => {
+    it('should parse simple plist string', () => {
+      const xml = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+          <dict>
+            <key>name</key>
+            <string>Test</string>
+            <key>value</key>
+            <integer>42</integer>
+            <key>enabled</key>
+            <boolean>true</boolean>
+          </dict>
+        </plist>
+      `;
+
+      const result = plistParser(xml);
+      expect(result).toEqual({
+        name: 'Test',
+        value: 42,
+        enabled: 'true',
+      });
+    });
+
+    it('should parse arrays in plist', () => {
+      const xml = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+          <dict>
+            <key>items</key>
+            <array>
+              <string>item1</string>
+              <string>item2</string>
+            </array>
+          </dict>
+        </plist>
+      `;
+
+      const result = plistParser(xml);
+      expect(result).toEqual({
+        items: ['item1', 'item2'],
+      });
+    });
+
+    it('should handle empty arrays', () => {
+      const xml = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+          <dict>
+            <key>items</key>
+            <array/>
+          </dict>
+        </plist>
+      `;
+
+      const result = plistParser(xml);
+      expect(result).toEqual({
+        items: [],
+      });
+    });
+  });
+
+  describe('strIsNumeric', () => {
+    it('should identify numeric strings', () => {
+      expect(strIsNumeric('123')).toBe(true);
+      expect(strIsNumeric('-123')).toBe(true);
+      expect(strIsNumeric('123.456')).toBe(true);
+    });
+
+    it('should return false for non-numeric strings', () => {
+      expect(strIsNumeric('abc')).toBe(false);
+      expect(strIsNumeric('')).toBe(false);
+    });
+
+    it('should return false for non-string inputs', () => {
+      expect(strIsNumeric(123)).toBe(false);
+      expect(strIsNumeric(null)).toBe(false);
+      expect(strIsNumeric(undefined)).toBe(false);
+      expect(strIsNumeric({})).toBe(false);
+    });
+  });
+});

--- a/server/src/tests/unit-tests/modules/remote-system-information/watchers/RemoteSystemInformationWatcher.test.ts
+++ b/server/src/tests/unit-tests/modules/remote-system-information/watchers/RemoteSystemInformationWatcher.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import CronJob from 'node-cron';
+import RemoteSystemInformationWatcher from '../../../../../modules/remote-system-information/watchers/RemoteSystemInformationWatcher';
+
+describe('RemoteSystemInformationWatcher', () => {
+  let watcher: RemoteSystemInformationWatcher;
+  let cronScheduleStub: ReturnType<typeof vi.fn>;
+  let loggerStub: {
+    info: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    debug: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    // Create stubs
+    cronScheduleStub = vi.spyOn(CronJob, 'schedule').mockReturnValue({
+      start: vi.fn(),
+      stop: vi.fn(),
+    } as any);
+
+    loggerStub = {
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    // Create watcher instance
+    watcher = new RemoteSystemInformationWatcher();
+    (watcher as any).logger = loggerStub;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('setupWatcher', () => {
+    it('should setup watcher with correct cron schedule', async () => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+      const config = { watch: true, cron: '*/5 * * * *' };
+      const name = 'TestWatcher';
+
+      (watcher as any).setupWatcher(name, handler, config);
+
+      expect(cronScheduleStub).toHaveBeenCalledWith(config.cron, expect.any(Function));
+      expect(loggerStub.info).toHaveBeenCalledWith(`Watching ${name}...`);
+
+      // Verify initial run
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle watcher errors gracefully', async () => {
+      const error = new Error('Watcher error');
+      const handler = vi.fn().mockRejectedValue(error);
+      const config = { watch: true, cron: '*/5 * * * *' };
+      const name = 'TestWatcher';
+
+      (watcher as any).setupWatcher(name, handler, config);
+
+      // Wait for error handler to be called
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(loggerStub.error).toHaveBeenCalledWith(`Error in initial ${name} watch:`, error);
+    });
+
+    it('should not setup watcher when watch is false', () => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+      const config = { watch: false, cron: '*/5 * * * *' };
+      const name = 'TestWatcher';
+
+      (watcher as any).setupWatcher(name, handler, config);
+
+      expect(cronScheduleStub).not.toHaveBeenCalled();
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deregisterComponent', () => {
+    it('should stop and remove watchers for a component', () => {
+      const stopStub = vi.fn();
+      const watcher1 = {
+        cron: { stop: stopStub },
+        handler: vi.fn(),
+        config: { watch: true, cron: '*/5 * * * *' },
+      };
+      const watcher2 = {
+        cron: { stop: stopStub },
+        handler: vi.fn(),
+        config: { watch: true, cron: '*/10 * * * *' },
+      };
+
+      (watcher as any).watchers = {
+        CPU_usage: watcher1,
+        Memory_usage: watcher2,
+      };
+
+      watcher.deregisterComponent();
+
+      expect(stopStub).toHaveBeenCalledTimes(2);
+      expect((watcher as any).watchers).not.toHaveProperty('CPU_usage');
+    });
+
+    it('should handle non-existent component gracefully', () => {
+      (watcher as any).watchers = {};
+      watcher.deregisterComponent();
+      expect(loggerStub.error).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Replaced synchronous `expect` statements with asynchronous `await expect` in several test files to improve consistency and correctness. Added new test cases for RemoteSystemInformationWatcher, Bluetooth utils, OS utils, and general utilities to ensure coverage of edge cases and input handling.