### PR TITLE
[BUG– Use Ant Design's built-in email validation

### DIFF
--- a/client/src/pages/User/FirstTime/CreateUserForm.tsx
+++ b/client/src/pages/User/FirstTime/CreateUserForm.tsx
@@ -47,7 +47,7 @@ const CreateUserForm = ({
       rules={[
         { required: true },
         {
-          pattern: /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/,
+          type: 'email',
           message: 'Please enter a valid email',
         },
       ]}


### PR DESCRIPTION
Replaced custom regex for email validation with Ant Design's `type: 'email'` rule. This simplifies code and improves maintainability while ensuring consistent validation behavior.