### PR TITLE
[FEAT] Enhance SFTP file download to support directories as tarballs

### DIFF
--- a/client/src/components/DeviceComponents/SFTPDrawer/Actions/DownloadModal.tsx
+++ b/client/src/components/DeviceComponents/SFTPDrawer/Actions/DownloadModal.tsx
@@ -76,15 +76,15 @@ const DownloadModal = React.forwardRef<
     fileBufferRef.current.push(chunk); // Append chunk directly to the mutable ref
   };
 
-  const handleError = (error: string) => {
-    message.error({
-      content: `Error during file download: ${error}`,
+  const handleError = (error: any) => {
+    void message.error({
+      content: `Error during file download: ${error?.message || error}`,
       duration: 6,
     });
   };
 
   const handleNotfound = (error: string) => {
-    message.error({
+    void message.error({
       content: `File not found: ${error}`,
       duration: 6,
     });


### PR DESCRIPTION
Updated the SFTP file handling logic to differentiate between files and directories. Added functionality to create and download tarballs for directories, ensuring efficient transfer. Improved error handling and logging for better debugging and user feedback during file operations.