### PR TITLE
[CHORE] Add unit tests for system utilities and RemoteOS features

### DIFF
--- a/server/src/tests/unit-tests/modules/remote-system-information/system-information/RemoteOS.test.ts
+++ b/server/src/tests/unit-tests/modules/remote-system-information/system-information/RemoteOS.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import { RemoteOS } from '../../../../../modules/remote-system-information/system-information/RemoteOS';
+import {
+  RemoteExecutorType,
+  RemoteExecutorTypeWithCallback,
+} from '../../../../../modules/remote-system-information/system-information/types';
+
+// Create a concrete implementation of RemoteOS for testing
+class TestRemoteOS extends RemoteOS {
+  constructor(execAsync: RemoteExecutorType, execWithCallback: RemoteExecutorTypeWithCallback) {
+    super(execAsync, execWithCallback);
+  }
+}
+
+describe('RemoteOS', () => {
+  let mockExecAsync: Mock<RemoteExecutorType>;
+  let mockExecWithCallback: Mock<RemoteExecutorTypeWithCallback>;
+  let remoteOS: TestRemoteOS;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Reset mocks before each test
+    mockExecAsync = vi.fn();
+    mockExecWithCallback = vi.fn();
+    remoteOS = new TestRemoteOS(mockExecAsync, mockExecWithCallback);
+  });
+
+  describe('OS Detection', () => {
+    it('should detect Linux OS', async () => {
+      mockExecAsync
+        .mockResolvedValue('default')
+        .mockResolvedValueOnce('Linux')
+        .mockResolvedValueOnce('Linux');
+      await remoteOS.init();
+      expect(remoteOS.platform).toBe('linux');
+    });
+
+    it('should detect macOS', async () => {
+      mockExecAsync
+        .mockResolvedValue('default')
+        .mockResolvedValueOnce('Darwin')
+        .mockResolvedValueOnce('Darwin');
+      await remoteOS.init();
+      expect(remoteOS.platform).toBe('darwin');
+    });
+  });
+
+  describe('System Information', () => {
+    it('should get system memory information', async () => {
+      // Mock Linux memory info
+      mockExecAsync.mockResolvedValueOnce('Linux'); // for OS detection
+      mockExecAsync.mockResolvedValueOnce('linux'); // for platform
+      mockExecAsync.mockResolvedValueOnce('linux'); // for platform
+      mockExecAsync.mockResolvedValueOnce('[]'); // for cpus
+      mockExecAsync.mockResolvedValueOnce('[]'); // for cpus
+      mockExecAsync.mockResolvedValueOnce('16384000');
+
+      await remoteOS.init();
+      const totalMem = await remoteOS['totalmem']();
+      expect(totalMem).toBeGreaterThan(0);
+    });
+
+    it('should get CPU information', async () => {
+      // Mock Linux CPU info
+      const cpuInfoMock = `
+processor       : 0
+model name      : Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+cpu MHz         : 2600.000
+
+processor       : 1
+model name      : Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+cpu MHz         : 2600.000
+`;
+      mockExecAsync.mockResolvedValueOnce('Linux'); // for OS detection
+      mockExecAsync.mockResolvedValueOnce('linux'); // for platform
+      mockExecAsync.mockResolvedValueOnce('linux'); // for platform
+      mockExecAsync.mockResolvedValueOnce(cpuInfoMock);
+      mockExecAsync.mockResolvedValueOnce('cpu0 2000 1000 3000 40000 0 0');
+      mockExecAsync.mockResolvedValueOnce('2600000');
+      mockExecAsync.mockResolvedValueOnce(cpuInfoMock);
+      mockExecAsync.mockResolvedValueOnce('cpu0 2000 1000 3000 40000 0 0');
+      mockExecAsync.mockResolvedValueOnce('2600000');
+      await remoteOS.init();
+      const cpus = await remoteOS['cpus']();
+
+      expect(cpus.length).toBeGreaterThan(0);
+      expect(cpus[0]).toHaveProperty('model');
+      expect(cpus[0]).toHaveProperty('speed');
+      expect(cpus[0]).toHaveProperty('times');
+    });
+
+    it('should get network interfaces', async () => {
+      // Mock Linux network interfaces
+      const networkMock = JSON.stringify([
+        {
+          ifname: 'eth0',
+          addr_info: [
+            {
+              local: '192.168.1.100',
+              prefixlen: 24,
+            },
+          ],
+          address: '00:11:22:33:44:55',
+          link_index: 1,
+        },
+      ]);
+
+      mockExecAsync.mockResolvedValueOnce('Linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('[]'); // for cpus
+      mockExecAsync.mockResolvedValueOnce('[]'); // for cpus
+      mockExecAsync.mockResolvedValueOnce(networkMock);
+
+      await remoteOS.init();
+      const interfaces = await remoteOS['osNetworkInterfaces']();
+
+      expect(interfaces).toHaveProperty('eth0');
+      expect(interfaces.eth0?.[0]).toHaveProperty('address', '192.168.1.100');
+      expect(interfaces.eth0?.[0]).toHaveProperty('family', 'IPv4');
+      expect(interfaces.eth0?.[0]).toHaveProperty('mac', '00:11:22:33:44:55');
+    });
+  });
+
+  describe('File System Operations', () => {
+    it('should check if file exists', async () => {
+      mockExecAsync.mockResolvedValueOnce('Linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('[]');
+      mockExecAsync.mockResolvedValueOnce('[]');
+      mockExecAsync.mockResolvedValueOnce('true');
+
+      await remoteOS.init();
+      const exists = await remoteOS['fileExists']('/path/to/file');
+      expect(exists).toBe(true);
+    });
+
+    it('should read file content', async () => {
+      const fileContent = 'test content';
+      mockExecAsync.mockResolvedValueOnce('Linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('[]');
+      mockExecAsync.mockResolvedValueOnce('[]');
+      mockExecAsync.mockResolvedValueOnce(fileContent);
+
+      await remoteOS.init();
+      const content = await remoteOS['readFileAsync']('/path/to/file');
+      expect(content).toBe(fileContent);
+    });
+
+    it('should list directories', async () => {
+      const dirs = '/path/dir1\n/path/dir2';
+      mockExecAsync.mockResolvedValueOnce('Linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('[]');
+      mockExecAsync.mockResolvedValueOnce('[]');
+      mockExecAsync.mockResolvedValueOnce(dirs);
+
+      await remoteOS.init();
+      const directories = await remoteOS['getDirectories']('/path');
+      expect(directories).toEqual(['/path/dir1', '/path/dir2']);
+    });
+  });
+
+  describe('System Metrics', () => {
+    it('should get system uptime', async () => {
+      mockExecAsync.mockResolvedValueOnce('Linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('[]');
+      mockExecAsync.mockResolvedValueOnce('[]');
+      mockExecAsync.mockResolvedValueOnce('12345.67 89012.34');
+
+      await remoteOS.init();
+      const uptime = await remoteOS['uptime']();
+      expect(uptime).toBe(12345);
+    });
+
+    it('should get load averages', async () => {
+      mockExecAsync.mockResolvedValueOnce('Linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('[]');
+      mockExecAsync.mockResolvedValueOnce('[]');
+      mockExecAsync.mockResolvedValueOnce('0.8 1.2 0.9');
+
+      await remoteOS.init();
+      const loadavg = await remoteOS['loadavg']();
+      expect(loadavg).toHaveLength(3);
+      expect(loadavg).toEqual([0.8, 1.2, 0.9]);
+    });
+  });
+
+  describe('Platform Specific Features', () => {
+    it('should detect Raspberry Pi', async () => {
+      const cpuInfo = [
+        'Hardware        : BCM2835',
+        'Model          : Raspberry Pi 4 Model B Rev 1.2',
+      ].join('\n');
+
+      mockExecAsync.mockResolvedValueOnce('Linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('[]');
+      mockExecAsync.mockResolvedValueOnce('[]');
+      mockExecAsync.mockResolvedValueOnce(cpuInfo);
+
+      await remoteOS.init();
+      const isRpi = await remoteOS['isRaspberry']();
+      expect(isRpi).toBe(true);
+    });
+
+    it('should detect Xcode on macOS', async () => {
+      mockExecAsync.mockResolvedValueOnce('Darwin');
+      mockExecAsync.mockResolvedValueOnce('darwin');
+      mockExecAsync.mockResolvedValueOnce('[]');
+      mockExecAsync.mockResolvedValueOnce('true');
+
+      await remoteOS.init();
+      const hasXcode = await remoteOS['darwinXcodeExists']();
+      expect(hasXcode).toBe(true);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle file read errors gracefully', async () => {
+      mockExecAsync.mockResolvedValueOnce('Linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('[]');
+      mockExecAsync.mockRejectedValueOnce(new Error('File not found'));
+
+      await remoteOS.init();
+      const exists = await remoteOS['fileExists']('/nonexistent/path');
+      expect(exists).toBe(false);
+    });
+
+    it('should handle network interface errors', async () => {
+      mockExecAsync.mockResolvedValueOnce('Linux');
+      mockExecAsync.mockResolvedValueOnce('linux');
+      mockExecAsync.mockResolvedValueOnce('[]');
+      mockExecAsync.mockRejectedValueOnce(new Error('Network error'));
+
+      await remoteOS.init();
+      await expect(remoteOS['osNetworkInterfaces']()).rejects.toThrow();
+    });
+  });
+});

--- a/server/src/tests/unit-tests/modules/remote-system-information/system-information/system/system.utils.test.ts
+++ b/server/src/tests/unit-tests/modules/remote-system-information/system-information/system/system.utils.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  macOsChassisType,
+  cleanDefaults,
+  getAppleModel,
+  parseDateTime
+} from '../../../../../../modules/remote-system-information/system-information/system/system.utils';
+
+describe('macOsChassisType', () => {
+  it('should identify MacBook Air models', () => {
+    expect(macOsChassisType('MacBookAir9,1')).toBe('Notebook');
+    expect(macOsChassisType('MacBook Air M1')).toBe('Notebook');
+  });
+
+  it('should identify MacBook Pro models', () => {
+    expect(macOsChassisType('MacBookPro16,2')).toBe('Notebook');
+    expect(macOsChassisType('MacBook Pro M1')).toBe('Notebook');
+  });
+
+  it('should identify MacBook models', () => {
+    expect(macOsChassisType('MacBook8,1')).toBe('Notebook');
+  });
+
+  it('should identify Mac Mini models', () => {
+    expect(macOsChassisType('Macmini8,1')).toBe('Desktop');
+    expect(macOsChassisType('Mac Mini M1')).toBe('Desktop');
+  });
+
+  it('should identify iMac models', () => {
+    expect(macOsChassisType('iMac20,1')).toBe('Desktop');
+  });
+
+  it('should identify Mac Studio models', () => {
+    expect(macOsChassisType('Mac Studio')).toBe('Desktop');
+    expect(macOsChassisType('MacStudio')).toBe('Desktop');
+  });
+
+  it('should identify Mac Pro models', () => {
+    expect(macOsChassisType('MacPro7,1')).toBe('Tower');
+    expect(macOsChassisType('Mac Pro')).toBe('Tower');
+  });
+
+  it('should return Other for unknown models', () => {
+    expect(macOsChassisType('Unknown Model')).toBe('Other');
+  });
+});
+
+describe('cleanDefaults', () => {
+  it('should clean default strings', () => {
+    expect(cleanDefaults('O.E.M.')).toBe('');
+    expect(cleanDefaults('Default String')).toBe('');
+    expect(cleanDefaults('Default')).toBe('');
+  });
+
+  it('should preserve valid strings', () => {
+    expect(cleanDefaults('MacBook Pro')).toBe('MacBook Pro');
+    expect(cleanDefaults('Intel Core i7')).toBe('Intel Core i7');
+  });
+
+  it('should handle empty strings', () => {
+    expect(cleanDefaults('')).toBe('');
+  });
+});
+
+describe('getAppleModel', () => {
+  it('should return model information for known models', () => {
+    const result = getAppleModel('MacBookPro11,4');
+    expect(result).toHaveProperty('key', 'MacBookPro11,4');
+    expect(result).toHaveProperty('model');
+    expect(result).toHaveProperty('version');
+  });
+
+  it('should return default values for unknown models', () => {
+    const result = getAppleModel('UnknownModel123');
+    expect(result).toEqual({
+      key: 'UnknownModel123',
+      model: 'Apple',
+      version: 'Unknown'
+    });
+  });
+});
+
+describe('parseDateTime', () => {
+  it('should parse mm/dd/yyyy format', () => {
+    const result = parseDateTime('12/25/2023 3:30 PM');
+    expect(result.date).toBe('2023-12-25');
+    expect(result.time).toBe('15:30');
+  });
+
+  it('should parse dd/mm/yyyy format with culture', () => {
+    const result = parseDateTime('25/12/2023 15:30', { dateFormat: 'dd/mm/yyyy' });
+    expect(result.date).toBe('2023-12-25');
+    expect(result.time).toBe('15:30');
+  });
+
+  it('should parse time with PM designator', () => {
+    const result = parseDateTime('2023/12/25 3:30 PM');
+    expect(result.time).toBe('15:30');
+  });
+
+  it('should parse time with AM designator', () => {
+    const result = parseDateTime('2023/12/25 9:30 AM');
+    expect(result.time).toBe('09:30');
+  });
+
+  it('should handle custom PM designator', () => {
+    const result = parseDateTime('25.12.2023 15:30', { 
+      dateFormat: 'dd.mm.yyyy',
+      pmDesignator: 'pm'
+    });
+    expect(result.date).toBe('2023-12-25');
+    expect(result.time).toBe('15:30');
+  });
+});


### PR DESCRIPTION
Introduces comprehensive unit tests for `system.utils` methods, including `macOsChassisType`, `cleanDefaults`, `getAppleModel`, and `parseDateTime`. Additionally, adds tests for `RemoteOS` functionality such as OS detection, system information retrieval, file operations, platform-specific checks, and error handling. These tests enhance the reliability and maintainability of the codebase.