### PR TITLE
[CHORE] Refactor SSH command execution to streamline privilege elevation

### DIFF
--- a/server/src/helpers/sudo/sudo.ts
+++ b/server/src/helpers/sudo/sudo.ts
@@ -18,51 +18,51 @@ export async function generateSudoCommand(deviceUuid: string): Promise<string> {
   switch (method) {
     case SsmAnsible.AnsibleBecomeMethod.SUDO:
       if (user && password) {
-        return `echo ${JSON.stringify(password)} | su - ${user}`;
+        return `echo ${JSON.stringify(password)} | su - ${user} -c "%command%"`;
       }
       // Sudo command with password
       if (password) {
-        return `echo ${JSON.stringify(password)} | sudo -S -p "" true`;
+        return `echo ${JSON.stringify(password)} | sudo -S -p "" %command%`;
       }
       // Sudo without password
-      return user ? `sudo -u ${user} true` : `sudo true`;
+      return user ? `sudo -u ${user} %command%` : `sudo %command%`;
 
     case SsmAnsible.AnsibleBecomeMethod.SU:
       // su command with password
       if (password) {
-        return `echo ${JSON.stringify(password)} | su ${user || ''}`;
+        return `echo ${JSON.stringify(password)} | su ${user || ''} -c "%command%"`;
       }
       // su without password
       return `su ${user || ''}`;
 
     case SsmAnsible.AnsibleBecomeMethod.PBRUN:
       // pbrun doesn't natively support password passing; use user if available
-      return user ? `pbrun -u ${user}` : `pbrun`;
+      return user ? `pbrun -u ${user} %command%` : `pbrun %command%`;
 
     case SsmAnsible.AnsibleBecomeMethod.PFEXEC:
       // pfexec (no password support; only provide user if available)
-      return user ? `pfexec -u ${user}` : `pfexec`;
+      return user ? `pfexec -u ${user} %command%` : `pfexec %command%`;
 
     case SsmAnsible.AnsibleBecomeMethod.DOAS:
       // doas (openbsd tool, may support user config in doas.conf)
-      return user ? `doas -u ${user}` : `doas`;
+      return user ? `doas -u ${user} %command%` : `doas %command%`;
 
     case SsmAnsible.AnsibleBecomeMethod.DZDO:
       // dzdo (Powerbroker; usually interactive, user pre-configured)
       if (user) {
         return password
-          ? `echo ${JSON.stringify(password)} | dzdo -u ${user} true`
-          : `dzdo -u ${user} true`;
+          ? `echo ${JSON.stringify(password)} | dzdo -u ${user} %command%`
+          : `dzdo -u ${user} %command%`;
       }
-      return `dzdo true`;
+      return `dzdo %command%`;
 
     case SsmAnsible.AnsibleBecomeMethod.KSU:
       // ksu (Kerberos su, user optional; may not support password)
-      return user ? `ksu ${user}` : `ksu`;
+      return user ? `ksu ${user} %command%` : `ksu %command%`;
 
     case SsmAnsible.AnsibleBecomeMethod.RUNAS:
       // runas (Windows-specific, password likely provided interactively)
-      return user ? `runas /user:${user}` : `runas`;
+      return user ? `runas /user:${user} %command%` : `runas %command%`;
 
     default:
       throw new Error(`Unsupported method: ${method}`);

--- a/server/src/modules/remote-system-information/system-information/types.d.ts
+++ b/server/src/modules/remote-system-information/system-information/types.d.ts
@@ -7,6 +7,7 @@ export interface RemoteExecOptions {
   maxBuffer?: number | undefined;
   encoding?: BufferEncoding | null | undefined;
   env?: NodeJS.ProcessEnv & { LANG: string };
+  elevatePrivilege?: boolean;
 }
 
 export type RemoteExecutorType = (cmd: string, options?: RemoteExecOptions) => Promise<string>;


### PR DESCRIPTION
Replaced in-line privilege elevation logic with a more unified and dynamic approach using `generateSudoCommand`. Removed unnecessary `isElevated` tracking and redundant privilege elevation method to simplify the codebase. This ensures privilege escalation is handled directly when executing commands, improving maintainability and consistency.