### PR TITLE
[CHORE] Enable SSH keep-alive mechanism upon connection establishment

### DIFF
--- a/server/src/modules/remote-system-information/core/RemoteSSHExecutorComponent.ts
+++ b/server/src/modules/remote-system-information/core/RemoteSSHExecutorComponent.ts
@@ -190,6 +190,7 @@ export default class RemoteSSHExecutorComponent extends Component {
         .on('ready', async () => {
           this.logger.info('SSH Connection established');
           retryAttempt = 0;
+          this.startKeepAlive();
           resolve(); // Connection successful
         })
         .on('error', (err) => {


### PR DESCRIPTION
Added a call to `startKeepAlive` after establishing an SSH connection. This ensures the connection remains active by sending periodic keep-alive signals, reducing the risk of unintended disconnections.