### PR TITLE
[CHORE] Add Dependabot config for Docker updates in /prometheus

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,9 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    # Look for a `Dockerfile` in the `root` directory
+    directory: "/prometheus"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This change introduces Dependabot configuration for Dockerfiles in the /prometheus directory. It ensures weekly checks for dependency updates, improving maintainability and security of the Docker setup.