### PR TITLE
[CHORE] Synchronize playbook defaults during device startup.

### DIFF
--- a/server/src/core/startup/index.ts
+++ b/server/src/core/startup/index.ts
@@ -81,6 +81,12 @@ class Startup {
 
     try {
       await DeviceModel.syncIndexes();
+      const devices = await DeviceRepo.findAll();
+      if (devices) {
+        for (const device of devices) {
+          void PlaybookModel.applyDefaults(device);
+        }
+      }
       this.logger.info('DeviceModel indexes synchronized successfully.');
     } catch (error: any) {
       this.logger.error(`Error synchronizing DeviceModel indexes: ${error.message}`);

--- a/server/src/tests/unit-tests/core/startup/Startup.test.ts
+++ b/server/src/tests/unit-tests/core/startup/Startup.test.ts
@@ -33,7 +33,9 @@ vi.mock('../../../../core/system/ansible-versions', () => ({
 vi.mock('../../../../modules/repository/default-playbooks-repositories', () => ({
   createADefaultLocalUserRepository: vi.fn(),
 }));
-
+vi.mock('../../../../data/database/repository/DeviceRepo', () => ({
+  default: { findAll: async () => [], findWithFilter: async () => [] },
+}));
 vi.mock('../../../../helpers/ansible/AnsibleConfigurationHelper', () => ({
   copyAnsibleCfgFileIfDoesntExist: vi.fn(),
 }));
@@ -81,6 +83,7 @@ describe('Startup Integration Tests', () => {
     vi.spyOn(ContainerCustomStackModel, 'updateMany').mockResolvedValue({});
     vi.spyOn(ContainerCustomStacksRepositoryModel, 'find').mockResolvedValue([]);
     vi.spyOn(ContainerVolumeModel, 'find').mockResolvedValue([]);
+
     // @ts-expect-error private fun
     vi.spyOn(PlaybookModel, 'syncIndexes').mockResolvedValue();
     // @ts-expect-error private fun


### PR DESCRIPTION
Added logic to apply default playbook configurations for all devices during the startup process. This ensures consistent initialization of devices after synchronizing indexes.