### PR TITLE
[CHORE] Upgrade to version 0.1.28 and remove unused dependency.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssm-client",
-  "version": "0.1.26",
+  "version": "0.1.28",
   "private": true,
   "description": "SSM Client - A simple way to manage all your servers",
   "author": "Squirrel Team",

--- a/server-demo/src/data/current-user.json
+++ b/server-demo/src/data/current-user.json
@@ -92,7 +92,7 @@
       "considerOffLineAfter": 3
     },
     "server": {
-      "version": "0.1.26",
+      "version": "0.1.28",
       "deps": {
         "@aws-sdk/client-ecr": "^3.632.0",
         "axios": "^1.7.4",

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
     "test:python:run": "cd ./src/ansible && python3 -m unittest discover -s . -p \"*.py\"",
     "coverage": "vitest run --coverage"
   },
-  "version": "0.1.26",
+  "version": "0.1.28",
   "author": "Squirrel Team",
   "dependencies": {
     "@aws-sdk/client-ecr": "^3.739.0",

--- a/server/src/core/startup/index.ts
+++ b/server/src/core/startup/index.ts
@@ -9,7 +9,6 @@ import { DeviceModel } from '../../data/database/model/Device';
 import { PlaybookModel } from '../../data/database/model/Playbook';
 import { PlaybooksRepositoryModel } from '../../data/database/model/PlaybooksRepository';
 import DeviceRepo from '../../data/database/repository/DeviceRepo';
-import DeviceStatRepo from '../../data/database/repository/DeviceStatRepo';
 import { copyAnsibleCfgFileIfDoesntExist } from '../../helpers/ansible/AnsibleConfigurationHelper';
 import PinoLogger from '../../logger';
 import RemoteSystemInformationEngine from '../../modules/remote-system-information/core/RemoteSystemInformationEngine';

--- a/shared-lib/package.json
+++ b/shared-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssm-shared-lib",
-  "version": "0.1.26",
+  "version": "0.1.28",
   "description": "",
   "main": "./distribution/index.js",
   "author": "Squirrel Team",


### PR DESCRIPTION
Bumped project version from 0.1.26 to 0.1.28 across all modules. Removed the unused `DeviceStatRepo` import from the server startup code to clean up unused references. This ensures consistency and prepares the codebase for future updates.