### PR TITLE
[CHORE] Add support for Remote System Information connection tests

### DIFF
--- a/client/src/services/rest/device.ts
+++ b/client/src/services/rest/device.ts
@@ -2,6 +2,10 @@
 /* eslint-disable */
 import { request } from '@umijs/max';
 import { API, SsmAgent } from 'ssm-shared-lib';
+import {
+  CheckAnsibleConnection,
+  Response,
+} from 'ssm-shared-lib/distribution/types/api';
 
 export async function getDevices(
   params?: API.PageParams,
@@ -56,11 +60,14 @@ export async function postCheckAnsibleConnection(
   masterNodeUrl?: string,
   options?: { [key: string]: any },
 ) {
-  return request<API.NewDevice>('/api/devices/check-connection/ansible', {
-    data: { ip: ip, masterNodeUrl: masterNodeUrl, ...deviceAuth },
-    method: 'POST',
-    ...(options || {}),
-  });
+  return request<API.Response<API.CheckAnsibleConnection>>(
+    '/api/devices/check-connection/ansible',
+    {
+      data: { ip: ip, masterNodeUrl: masterNodeUrl, ...deviceAuth },
+      method: 'POST',
+      ...(options || {}),
+    },
+  );
 }
 
 export async function postCheckDockerConnection(
@@ -68,18 +75,36 @@ export async function postCheckDockerConnection(
   deviceAuth: API.DeviceAuthParams,
   options?: { [key: string]: any },
 ) {
-  return request<API.NewDevice>('/api/devices/check-connection/docker', {
-    data: { ip: ip, ...deviceAuth },
-    method: 'POST',
-    ...(options || {}),
-  });
+  return request<API.Response<API.CheckDockerConnection>>(
+    '/api/devices/check-connection/docker',
+    {
+      data: { ip: ip, ...deviceAuth },
+      method: 'POST',
+      ...(options || {}),
+    },
+  );
+}
+
+export async function postCheckRemoteSystemInformationConnection(
+  ip: string,
+  deviceAuth: API.DeviceAuthParams,
+  options?: { [key: string]: any },
+) {
+  return request<API.Response<API.CheckRemoteSystemInformationConnection>>(
+    '/api/devices/check-connection/remote-system-information',
+    {
+      data: { ip: ip, ...deviceAuth },
+      method: 'POST',
+      ...(options || {}),
+    },
+  );
 }
 
 export async function deleteDevice(
   uuid: string,
   options?: { [key: string]: any },
 ) {
-  return request<API.SimpleResult>(`/api/devices/${uuid}`, {
+  return request<API.Response<API.SimpleResult>>(`/api/devices/${uuid}`, {
     method: 'DELETE',
     ...(options || {}),
   });
@@ -96,7 +121,7 @@ export async function updateDeviceDockerConfiguration(
   },
   options?: { [key: string]: any },
 ) {
-  return request<API.SimpleResult>(
+  return request<API.Response<API.SimpleResult>>(
     `/api/devices/${uuid}/configuration/containers/docker`,
     {
       method: 'POST',
@@ -113,7 +138,7 @@ export async function updateDeviceSystemInformationConfiguration(
   systemInformationConfiguration: Partial<API.SystemInformationConfiguration>,
   options?: { [key: string]: any },
 ) {
-  return request<API.SimpleResult>(
+  return request<API.Response<API.SimpleResult>>(
     `/api/devices/${uuid}/configuration/system-information`,
     {
       method: 'POST',
@@ -130,7 +155,7 @@ export async function updateDeviceProxmoxConfiguration(
   proxmoxConfiguration: API.ProxmoxConfiguration,
   options?: { [key: string]: any },
 ) {
-  return request<API.SimpleResult>(
+  return request<API.Response<API.SimpleResult>>(
     `/api/devices/${uuid}/configuration/containers/proxmox`,
     {
       method: 'POST',
@@ -144,7 +169,7 @@ export async function getCheckDeviceDockerConnection(
   uuid: string,
   options?: { [key: string]: any },
 ) {
-  return request<API.SimpleResult>(
+  return request<API.Response<API.CheckDockerConnection>>(
     `/api/devices/${uuid}/auth/docker/test-connection`,
     {
       method: 'GET',
@@ -157,8 +182,21 @@ export async function getCheckDeviceAnsibleConnection(
   uuid: string,
   options?: { [key: string]: any },
 ) {
-  return request<API.SimpleResult>(
+  return request<API.Response<API.CheckAnsibleConnection>>(
     `/api/devices/${uuid}/auth/ansible/test-connection`,
+    {
+      method: 'GET',
+      ...(options || {}),
+    },
+  );
+}
+
+export async function getCheckDeviceRemoteSystemInformationConnection(
+  uuid: string,
+  options?: { [key: string]: any },
+) {
+  return request<API.Response<API.CheckRemoteSystemInformationConnection>>(
+    `/api/devices/${uuid}/auth/remote-system-information/test-connection`,
     {
       method: 'GET',
       ...(options || {}),
@@ -187,10 +225,13 @@ export async function postDeviceDiagnostic(
   uuid: string,
   options?: { [key: string]: any },
 ) {
-  return request<API.SimpleResult>(`/api/devices/${uuid}/auth/diagnostic`, {
-    method: 'POST',
-    ...(options || {}),
-  });
+  return request<API.Response<API.SimpleResult>>(
+    `/api/devices/${uuid}/auth/diagnostic`,
+    {
+      method: 'POST',
+      ...(options || {}),
+    },
+  );
 }
 
 export async function postDeviceCapabilities(

--- a/server/src/controllers/rest/devices/check-connection.ts
+++ b/server/src/controllers/rest/devices/check-connection.ts
@@ -1,4 +1,5 @@
 import { API } from 'ssm-shared-lib';
+import { CheckRemoteSystemInformationConnection } from 'ssm-shared-lib/distribution/types/api';
 import DeviceAuthRepo from '../../../data/database/repository/DeviceAuthRepo';
 import DeviceRepo from '../../../data/database/repository/DeviceRepo';
 import { preWriteSensitiveInfos } from '../../../helpers/sensitive/handle-sensitive-info';
@@ -75,6 +76,33 @@ export const postCheckDockerConnection = async (req, res) => {
   }
 };
 
+export const postCheckRemoteSystemInformationConnection = async (req, res) => {
+  const { ip, authType, sshKey, sshUser, sshPwd, sshPort, becomeMethod, becomePass, sshKeyPass } =
+    req.body;
+  if (!req.user) {
+    throw new ForbiddenError();
+  }
+  const result = await DeviceUseCases.checkDockerConnection(
+    ip,
+    authType,
+    sshKey,
+    sshUser,
+    sshPwd,
+    sshPort,
+    becomeMethod,
+    becomePass,
+    sshKeyPass,
+  );
+  try {
+    new SuccessResponse('Post CheckRemoteSystemInformationConnection', {
+      connectionStatus: result.status,
+      errorMessage: result.message,
+    } as API.CheckRemoteSystemInformationConnection).send(res);
+  } catch (error: any) {
+    throw new InternalError(error.message);
+  }
+};
+
 export const getCheckDeviceDockerConnection = async (req, res) => {
   const { uuid } = req.params;
   const device = await DeviceRepo.findOneByUuid(uuid);
@@ -88,6 +116,30 @@ export const getCheckDeviceDockerConnection = async (req, res) => {
   try {
     const result = await DeviceUseCases.checkDeviceDockerConnection(device, deviceAuth);
     new SuccessResponse('Post CheckDeviceDockerConnection', {
+      connectionStatus: result.status,
+      errorMessage: result.message,
+    } as API.CheckDockerConnection).send(res);
+  } catch (error: any) {
+    throw new InternalError(error.message);
+  }
+};
+
+export const getCheckDeviceRemoteSystemInformationConnection = async (req, res) => {
+  const { uuid } = req.params;
+  const device = await DeviceRepo.findOneByUuid(uuid);
+  if (!device) {
+    throw new NotFoundError('Device ID not found');
+  }
+  const deviceAuth = await DeviceAuthRepo.findOneByDevice(device);
+  if (!deviceAuth) {
+    throw new NotFoundError('Device Auth not found');
+  }
+  try {
+    const result = await DeviceUseCases.checkDeviceRemoteSystemInformationConnection(
+      device,
+      deviceAuth,
+    );
+    new SuccessResponse('Post getCheckDeviceRemoteSystemInformationConnection', {
       connectionStatus: result.status,
       errorMessage: result.message,
     } as API.CheckDockerConnection).send(res);

--- a/server/src/controllers/rest/devices/check-connection.validator.ts
+++ b/server/src/controllers/rest/devices/check-connection.validator.ts
@@ -96,6 +96,16 @@ export const getCheckDeviceDockerConnectionValidator = [
   validator,
 ];
 
+export const getCheckDeviceRemoteSystemInformationConnectionValidator = [
+  param('uuid')
+    .exists()
+    .notEmpty()
+    .withMessage('Uuid is required')
+    .isUUID()
+    .withMessage('Uuid is not valid'),
+  validator,
+];
+
 export const getCheckDeviceAnsibleConnectionValidator = [
   param('uuid')
     .exists()

--- a/server/src/modules/remote-system-information/core/RemoteSSHExecutorComponent.ts
+++ b/server/src/modules/remote-system-information/core/RemoteSSHExecutorComponent.ts
@@ -209,6 +209,34 @@ export default class RemoteSSHExecutorComponent extends Component {
     });
   }
 
+  public static async testConnection(config: ConnectConfig): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const conn = new Client();
+      conn
+        .on('ready', () => {
+          conn.exec('echo', (err, stream) => {
+            if (err) {
+              conn.end(); // Close the connection after the test succeeds
+              reject(err);
+            }
+            stream.on('exit', (code: number, signal: any) => {
+              if (code === 0) {
+                conn.end(); // Close the connection after the test succeeds
+                resolve();
+              } else {
+                conn.end(); // Close the connection after the test succeeds
+                reject(new Error(`Connection failed with code ${code}, signal: ${signal}`));
+              }
+            });
+          });
+        })
+        .on('error', (err) => {
+          reject(err); // Return the error if connection fails
+        })
+        .connect(config); // Connect using provided configuration
+    });
+  }
+
   // Reconnection logic
   private async reconnect(retryAttempt = 0): Promise<void> {
     // If already reconnecting, return the existing promise

--- a/server/src/routes/devices.ts
+++ b/server/src/routes/devices.ts
@@ -6,14 +6,17 @@ import {
   getCheckDeviceAnsibleConnection,
   getCheckDeviceDockerConnection,
   getCheckDeviceProxmoxConnection,
+  getCheckDeviceRemoteSystemInformationConnection,
   postCheckAnsibleConnection,
   postCheckDockerConnection,
+  postCheckRemoteSystemInformationConnection,
   postDiagnostic,
 } from '../controllers/rest/devices/check-connection';
 import {
   getCheckDeviceAnsibleConnectionValidator,
   getCheckDeviceDockerConnectionValidator,
   getCheckDeviceProxmoxConnectionValidator,
+  getCheckDeviceRemoteSystemInformationConnectionValidator,
   postCheckAnsibleConnectionValidator,
   postCheckDockerConnectionValidator,
   postDiagnosticValidator,
@@ -93,6 +96,11 @@ router.post(
   postCheckDockerConnectionValidator,
   postCheckDockerConnection,
 );
+router.post(
+  '/check-connection/remote-system-information',
+  postCheckDockerConnectionValidator,
+  postCheckRemoteSystemInformationConnection,
+);
 
 router.get(`/dashboard/stats/performances`, getDashboardPerformanceStats);
 router.post(
@@ -141,6 +149,13 @@ router
 router
   .route('/:uuid/auth/proxmox/test-connection')
   .post(getCheckDeviceProxmoxConnectionValidator, getCheckDeviceProxmoxConnection);
+router
+  .route('/:uuid/auth/remote-system-information/test-connection')
+  .get(
+    getCheckDeviceRemoteSystemInformationConnectionValidator,
+    getCheckDeviceRemoteSystemInformationConnection,
+  );
+
 router.post('/:uuid/auth/diagnostic', postDiagnosticValidator, postDiagnostic);
 
 router.route('/').put(addDeviceValidator, addDevice).get(getDevices);

--- a/shared-lib/src/types/api.ts
+++ b/shared-lib/src/types/api.ts
@@ -166,6 +166,11 @@ export type CheckDockerConnection = {
   errorMessage?: string;
 }
 
+export type CheckRemoteSystemInformationConnection = {
+  connectionStatus: string;
+  errorMessage?: string;
+}
+
 export type DeviceCapabilities = {
   containers: {
     docker: {


### PR DESCRIPTION
Introduced functionality to validate Remote System Information connection during device setup and diagnostics. Updated client, server, and shared-lib components to integrate this feature, including API endpoints, UI adjustments, and backend logic for connection testing.