### PR TITLE
[DOC] Add Prometheus integration to Docker setup and documentation

### DIFF
--- a/site/docs/devices/configuration/diagnostic.md
+++ b/site/docs/devices/configuration/diagnostic.md
@@ -3,6 +3,6 @@
 ## Overview
 ![Diagnostic Tab](/device-configuration/diagnostic/diagnostic-1.png)
 
-The **Diagnostic** tab allows you to run Ansible and Docker connection tests to validate whether SSM can successfully connect to and retrieve information from your device.
+The **Diagnostic** tab allows you to run Ansible, Remote System Information (only in agentless mode) and Docker connection tests to validate whether SSM can successfully connect to and retrieve information from your device.
 
 Advanced diagnostic tests perform a series of checks to further diagnose and troubleshoot connection issues.

--- a/site/docs/install/docker.md
+++ b/site/docs/install/docker.md
@@ -20,9 +20,18 @@ services:
       - mongo
       - server
       - redis
+      - prometheus
     labels:
       wud.display.name: "SSM - Proxy"
       wud.watch.digest: false
+  prometheus:
+    image: "ghcr.io/squirrelcorporation/squirrelserversmanager-prometheus:latest"
+    container_name: prometheus-ssm
+    restart: unless-stopped
+    volumes:
+      - ./.data.prod/prometheus:/prometheus
+    labels:
+      wud.display.name: "SSM - Prometheus"
   mongo:
     container_name: mongo-ssm
     image: mongo
@@ -53,9 +62,11 @@ services:
     external_links:
       - mongo
       - redis
+      - prometheus
     depends_on:
       - mongo
       - redis
+      - prometheus
     env_file: .env
     environment:
       NODE_ENV: production

--- a/site/docs/quickstart.md
+++ b/site/docs/quickstart.md
@@ -36,9 +36,18 @@ services:
       - mongo
       - server
       - redis
+      - prometheus
     labels:
       wud.display.name: "SSM - Proxy"
       wud.watch.digest: false
+  prometheus:
+    image: "ghcr.io/squirrelcorporation/squirrelserversmanager-prometheus:latest"
+    container_name: prometheus-ssm
+    restart: unless-stopped
+    volumes:
+      - ./.data.prod/prometheus:/prometheus
+    labels:
+      wud.display.name: "SSM - Prometheus"
   mongo:
     container_name: mongo-ssm
     image: mongo
@@ -69,9 +78,11 @@ services:
     external_links:
       - mongo
       - redis
+      - prometheus
     depends_on:
       - mongo
       - redis
+      - prometheus
     env_file: .env
     environment:
       NODE_ENV: production


### PR DESCRIPTION
Updated the Docker configurations and documentation to include support for Prometheus. Added Prometheus as a service in docker-compose files and adjusted dependencies accordingly. Also modified the diagnostic tab documentation to reflect new diagnostic capabilities.