### PR TITLE
Resolve Prometheus Directory Creation Issue 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,9 @@ services:
     container_name: prometheus-ssm
     restart: unless-stopped
     env_file: .env
-    volumes:
+   volumes:
       - ./.data.prod/prometheus:/prometheus
+    entrypoint: ["/bin/sh", "-c", "mkdir -p /prometheus/data && chmod -R 777 /prometheus/data && /bin/prometheus"]
     labels:
       wud.display.name: "SSM - Prometheus"
   mongo:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     container_name: prometheus-ssm
     restart: unless-stopped
     env_file: .env
-   volumes:
+    volumes:
       - ./.data.prod/prometheus:/prometheus
     entrypoint: ["/bin/sh", "-c", "mkdir -p /prometheus/data && chmod -R 777 /prometheus/data && /bin/prometheus"]
     labels:


### PR DESCRIPTION
This commit addresses an issue where the Prometheus service in the SSM (Squirrel Servers Manager) Docker Compose setup failed to start due to a missing directory for logging active queries. The specific error messages indicated that the directory `/prometheus/data` did not exist, preventing Prometheus from starting correctly.

**Issue Details:**
- Prometheus logs showed errors related to the missing directory and file for active query logging.
- The error messages were:
  ```plaintext
  prometheus-ssm  | time=2025-02-13T19:46:25.772Z level=ERROR source=query_logger.go:137 msg="Failed to create directory for logging active queries" component=activeQueryTracker
  prometheus-ssm  | time=2025-02-13T19:46:25.772Z level=ERROR source=query_logger.go:113 msg="Error opening query log file" component=activeQueryTracker file=/prometheus/data/queries.active err="open data/queries.active: no such file or directory"
  prometheus-ssm  | panic: Unable to create mmap-ed active query log
  ```

**Fix Details:**
1. **Modified the Prometheus Service Entry Point**: Updated the entrypoint for the Prometheus service to include commands that create the necessary directory and set the appropriate permissions.
   ```yaml
   prometheus:
     image: ghcr.io/squirrelcorporation/squirrelserversmanager-prometheus:latest
     container_name: prometheus-ssm
     restart: unless-stopped
     volumes:
       - ./.data.prod/prometheus:/prometheus
     entrypoint: ["/bin/sh", "-c", "mkdir -p /prometheus/data && chmod -R 777 /prometheus/data && /bin/prometheus"]
     labels:
       wud.display.name: SSM - Prometheus
     networks:
       - backend
   ```

2. **Applied Changes**: Restarted the Docker Compose services to apply the changes.
   ```sh
   docker-compose down
   docker-compose up -d
   ```

3. **Verified Logs**: Checked the logs for the Prometheus service to confirm that the issue was resolved.
   ```sh
   docker-compose logs prometheus
   ```

By making these changes, the issue with the missing directory for logging active queries has been resolved, and Prometheus is now able to start correctly.


Fixed By me , commit description was written by MistralAI