### PR TITLE
[BUG] Add support for "watch all containers" configuration

### DIFF
--- a/client/src/components/DeviceConfiguration/DockerConfigurationFormElements.tsx
+++ b/client/src/components/DeviceConfiguration/DockerConfigurationFormElements.tsx
@@ -45,7 +45,7 @@ export const DockerConfigurationFormElements: React.FC<
         initialValue={device.capabilities?.containers?.docker?.enabled || true}
         onChange={handleOnChangeCapability}
       />
-      <DockerWatchCard device={device} />
+      <DockerWatchCard device={device} showAdvanced={showAdvanced} />
       <DockerEngineHostCard
         device={device}
         showAdvanced={showAdvanced}

--- a/client/src/components/DeviceConfiguration/docker/DockerWatchCard.tsx
+++ b/client/src/components/DeviceConfiguration/docker/DockerWatchCard.tsx
@@ -9,9 +9,10 @@ import { API } from 'ssm-shared-lib';
 
 interface DockerWatchCardProps {
   device: Partial<API.DeviceItem>;
+  showAdvanced: boolean;
 }
 
-const DockerWatchCard = ({ device }: DockerWatchCardProps) => {
+const DockerWatchCard = ({ device, showAdvanced }: DockerWatchCardProps) => {
   const [dockerWatcher, setDockerWatcher] = useState<boolean>(
     device.configuration?.containers?.docker?.watchContainers ?? true,
   );
@@ -21,6 +22,28 @@ const DockerWatchCard = ({ device }: DockerWatchCardProps) => {
   const [dockerStatsWatcher, setDockerStatsWatcher] = useState<boolean>(
     device.configuration?.containers?.docker?.watchContainersStats ?? true,
   );
+  const [dockerWatchAll, setDockerWatchAll] = useState<boolean>(
+    device.configuration?.containers?.docker?.watchAll ?? true,
+  );
+
+  const handleOnChangeDockerWatchAll = async () => {
+    if (device.uuid) {
+      await updateDeviceDockerConfiguration(device.uuid, {
+        dockerWatcher: dockerWatcher,
+        dockerStatsWatcher: dockerStatsWatcher,
+        dockerEventsWatcher: dockerEventsWatcher,
+        dockerWatchAll: !dockerWatchAll,
+      }).then((response) => {
+        setDockerWatcher(response.data.dockerWatcher);
+        setDockerEventsWatcher(response.data.dockerEventsWatcher);
+        setDockerStatsWatcher(response.data.dockerStatsWatcher);
+        setDockerWatchAll(response.data.dockerWatchAll);
+        message.success({ content: 'Setting updated' });
+      });
+    } else {
+      message.error({ content: 'Internal error - no device id' });
+    }
+  };
 
   const handleOnChangeDockerWatcher = async () => {
     if (device.uuid) {
@@ -28,10 +51,12 @@ const DockerWatchCard = ({ device }: DockerWatchCardProps) => {
         dockerWatcher: !dockerWatcher,
         dockerStatsWatcher: dockerStatsWatcher,
         dockerEventsWatcher: dockerEventsWatcher,
+        dockerWatchAll: dockerWatchAll,
       }).then((response) => {
         setDockerWatcher(response.data.dockerWatcher);
         setDockerEventsWatcher(response.data.dockerEventsWatcher);
         setDockerStatsWatcher(response.data.dockerStatsWatcher);
+        setDockerWatchAll(response.data.dockerWatchAll);
         message.success({ content: 'Setting updated' });
       });
     } else {
@@ -45,10 +70,12 @@ const DockerWatchCard = ({ device }: DockerWatchCardProps) => {
         dockerWatcher: dockerWatcher,
         dockerStatsWatcher: !dockerStatsWatcher,
         dockerEventsWatcher: dockerEventsWatcher,
+        dockerWatchAll: dockerWatchAll,
       }).then((response) => {
         setDockerWatcher(response.data.dockerWatcher);
         setDockerEventsWatcher(response.data.dockerEventsWatcher);
         setDockerStatsWatcher(response.data.dockerStatsWatcher);
+        setDockerWatchAll(response.data.dockerWatchAll);
         message.success({ content: 'Setting updated' });
       });
     } else {
@@ -62,10 +89,12 @@ const DockerWatchCard = ({ device }: DockerWatchCardProps) => {
         dockerWatcher: dockerWatcher,
         dockerStatsWatcher: dockerStatsWatcher,
         dockerEventsWatcher: !dockerEventsWatcher,
+        dockerWatchAll: dockerWatchAll,
       }).then((response) => {
         setDockerWatcher(response.data.dockerWatcher);
         setDockerEventsWatcher(response.data.dockerEventsWatcher);
         setDockerStatsWatcher(response.data.dockerStatsWatcher);
+        setDockerWatchAll(response.data.dockerWatchAll);
         message.success({ content: 'Setting updated' });
       });
     } else {
@@ -120,6 +149,18 @@ const DockerWatchCard = ({ device }: DockerWatchCardProps) => {
           }}
         />
       </ProForm.Group>
+      {showAdvanced && (
+        <ProForm.Group>
+          <ProFormSwitch
+            checkedChildren={'Watch All Containers'}
+            unCheckedChildren={'Watch Only Running Containers'}
+            fieldProps={{
+              value: dockerWatchAll,
+              onChange: handleOnChangeDockerWatchAll,
+            }}
+          />
+        </ProForm.Group>
+      )}
     </Card>
   );
 };

--- a/client/src/services/rest/device.ts
+++ b/client/src/services/rest/device.ts
@@ -2,10 +2,6 @@
 /* eslint-disable */
 import { request } from '@umijs/max';
 import { API, SsmAgent } from 'ssm-shared-lib';
-import {
-  CheckAnsibleConnection,
-  Response,
-} from 'ssm-shared-lib/distribution/types/api';
 
 export async function getDevices(
   params?: API.PageParams,
@@ -118,6 +114,7 @@ export async function updateDeviceDockerConfiguration(
     dockerEventsWatcher: boolean;
     dockerWatcherCron?: string;
     dockerStatsCron?: string;
+    dockerWatchAll?: boolean;
   },
   options?: { [key: string]: any },
 ) {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,7 +19,6 @@ services:
       context: ./prometheus  # Directory containing Dockerfile and prometheus.yml
     container_name: prometheus-ssm
     restart: unless-stopped
-    entrypoint: [ "/bin/sh", "-c", "mkdir -p /prometheus/data && chmod -R 755 /prometheus && /entrypoint.sh" ]
     env_file:
       - ./.env.dev
     volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,6 +19,7 @@ services:
       context: ./prometheus  # Directory containing Dockerfile and prometheus.yml
     container_name: prometheus-ssm
     restart: unless-stopped
+    entrypoint: [ "/bin/sh", "-c", "mkdir -p /prometheus/data && chmod -R 755 /prometheus && /entrypoint.sh" ]
     env_file:
       - ./.env.dev
     volumes:

--- a/server/src/controllers/rest/devices/configuration.ts
+++ b/server/src/controllers/rest/devices/configuration.ts
@@ -53,6 +53,7 @@ export const updateDockerWatcher = async (req, res) => {
     dockerStatsWatcher,
     dockerStatsCron,
     dockerEventsWatcher,
+    dockerWatchAll,
   } = req.body;
   const device = await DeviceRepo.findOneByUuid(req.params.uuid);
 
@@ -66,6 +67,7 @@ export const updateDockerWatcher = async (req, res) => {
     dockerStatsWatcher,
     dockerStatsCron,
     dockerEventsWatcher,
+    dockerWatchAll,
   );
   new SuccessResponse('Update docker watcher flag successful', {
     dockerWatcher: dockerWatcher,
@@ -73,5 +75,6 @@ export const updateDockerWatcher = async (req, res) => {
     dockerStatsWatcher: dockerStatsWatcher,
     dockerEventsWatcher: dockerEventsWatcher,
     dockerStatsCron: dockerStatsCron,
+    dockerWatchAll: dockerWatchAll,
   }).send(res);
 };

--- a/server/src/data/database/model/Device.ts
+++ b/server/src/data/database/model/Device.ts
@@ -33,6 +33,7 @@ export default interface Device {
         watchContainersStats?: boolean;
         watchContainersStatsCron?: string;
         watchEvents?: boolean;
+        watchAll?: boolean;
       };
     };
     systemInformation?: {
@@ -295,6 +296,11 @@ const DockerConfigurationSchema = new Schema<Device['configuration']['containers
     default: true,
   },
   watchEvents: {
+    type: Schema.Types.Boolean,
+    required: true,
+    default: true,
+  },
+  watchAll: {
     type: Schema.Types.Boolean,
     required: true,
     default: true,

--- a/server/src/modules/containers/core/WatcherEngine.ts
+++ b/server/src/modules/containers/core/WatcherEngine.ts
@@ -154,6 +154,7 @@ async function registerWatchers(): Promise<any> {
             cronstats: device.configuration.containers.docker?.watchContainersStatsCron as string,
             watchevents: device.configuration.containers.docker?.watchEvents as boolean,
             host: device.ip as string,
+            watchall: device.configuration.containers.docker?.watchAll as boolean,
           },
         ),
       );

--- a/server/src/modules/containers/watchers/providers/docker/Docker.ts
+++ b/server/src/modules/containers/watchers/providers/docker/Docker.ts
@@ -62,7 +62,7 @@ export default class Docker extends DockerLogs {
       watchstats: this.joi.boolean().default(true),
       cronstats: this.joi.string().default('*/1 * * * *'),
       watchbydefault: this.joi.boolean().default(true),
-      watchall: this.joi.boolean().default(false),
+      watchall: this.joi.boolean().default(true),
       watchevents: this.joi.boolean().default(true),
       deviceUuid: this.joi.string().required(),
     });

--- a/server/src/services/DeviceUseCases.ts
+++ b/server/src/services/DeviceUseCases.ts
@@ -100,6 +100,7 @@ async function updateDockerWatcher(
   dockerStatsWatcher?: boolean,
   dockerStatsCron?: string,
   dockerEventsWatcher?: boolean,
+  dockerWatchAll?: boolean,
 ) {
   logger.info(`updateDockerWatcher - DeviceUuid: ${device.uuid}`);
   if (!device.configuration.containers.docker) {
@@ -110,6 +111,7 @@ async function updateDockerWatcher(
   device.configuration.containers.docker.watchContainersStatsCron = dockerStatsCron;
   device.configuration.containers.docker.watchContainersStats = dockerStatsWatcher;
   device.configuration.containers.docker.watchEvents = dockerEventsWatcher;
+  device.configuration.containers.docker.watchAll = dockerWatchAll;
   await DeviceRepo.update(device);
 }
 

--- a/shared-lib/src/types/api.ts
+++ b/shared-lib/src/types/api.ts
@@ -1,12 +1,12 @@
 import { ExtraVarsType, SSHConnection, SSHType } from '../enums/ansible';
 import { ContainerTypes, VolumeBackupMode } from '../enums/container';
 import { Services } from '../enums/git';
+import * as SsmProxmox from '../enums/proxmox';
 import { RepositoryType } from '../enums/repositories';
 import { AutomationChain } from '../form/automation';
 import { ProxmoxModel } from '../namespace/proxmox';
 import { Systeminformation } from '../namespace/system-information';
 import { ExtendedTreeNode } from './tree';
-import * as SsmProxmox from '../enums/proxmox'
 
 export type Response<T> = {
   success: boolean;
@@ -258,6 +258,7 @@ export type DeviceConfiguration = {containers: {
         watchContainersStats?: boolean;
         watchContainersStatsCron?: string;
         watchEvents?: boolean;
+        watchAll?: boolean;
       };
     };
     systemInformation?:SystemInformationConfiguration;


### PR DESCRIPTION
Introduce a new `dockerWatchAll` flag to enable watching all containers, including stopped ones. Updated server, client, and database schema to handle the new configuration, and modified UI components to allow toggling the feature in advanced settings. Additionally, adjusted default behavior in Docker runtime to reflect this change.