### PR TITLE
[BUG] Set up proper permissions and user context for Prometheus

### DIFF
--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -1,4 +1,3 @@
-# Use the official Prometheus base image
 FROM prom/prometheus:latest
 
 # Copy your base Prometheus configuration file to the image
@@ -6,10 +5,9 @@ COPY prometheus.base.yml /etc/prometheus/prometheus.base.yml
 
 # Copy your custom entrypoint script
 COPY entrypoint.sh /entrypoint.sh
-USER root
-# Ensure the entrypoint script is executable
-RUN chmod +x /entrypoint.sh
-USER nobody
 
-# Override the default CMD with the entrypoint script
+USER root
+# Make the entrypoint executable
+RUN chmod +x /entrypoint.sh
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/prometheus/entrypoint.sh
+++ b/prometheus/entrypoint.sh
@@ -4,6 +4,11 @@
 BASE_CONFIG="/etc/prometheus/prometheus.base.yml"
 DYNAMIC_CONFIG="/etc/prometheus/prometheus.yml"
 
+# Set up the data directory with correct permissions
+mkdir -p /prometheus/data
+chmod -R 755 /prometheus
+chown -R nobody:nobody /prometheus
+
 # Check if values for authentication are provided through environment variables
 if [ -n "$PROMETHEUS_USERNAME" ] && [ -n "$PROMETHEUS_PASSWORD" ]; then
   echo "Configuring Prometheus with authentication..."
@@ -15,4 +20,4 @@ else
 fi
 
 # Start Prometheus
-/bin/prometheus --config.file="$DYNAMIC_CONFIG"
+exec su -s /bin/sh nobody -c "/bin/prometheus --config.file=\"$DYNAMIC_CONFIG\""


### PR DESCRIPTION
Ensure the Prometheus data directory has correct permissions and ownership. Adjusted the entrypoint script to run Prometheus as the `nobody` user for improved security. Updated the Dockerfile to simplify the user setup and maintain compatibility with the modified entrypoint script.