### PR TITLE
[CHORE] Bump version to 0.1.29 across all packages

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssm-client",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": true,
   "description": "SSM Client - A simple way to manage all your servers",
   "author": "Squirrel Team",

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
     "test:python:run": "cd ./src/ansible && python3 -m unittest discover -s . -p \"*.py\"",
     "coverage": "vitest run --coverage"
   },
-  "version": "0.1.28",
+  "version": "0.1.29",
   "author": "Squirrel Team",
   "dependencies": {
     "@aws-sdk/client-ecr": "^3.744.0",

--- a/shared-lib/package.json
+++ b/shared-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssm-shared-lib",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "",
   "main": "./distribution/index.js",
   "author": "Squirrel Team",


### PR DESCRIPTION
Updated the version number in client, server, and shared-lib package.json files to 0.1.29. This ensures consistency across all components and prepares the packages for release. No other changes were made.