### PR TITLE
Potential fix for code scanning alert no. 45: Database query built from user-controlled sources

### DIFF
--- a/server/src/data/database/repository/AnsibleTaskRepo.ts
+++ b/server/src/data/database/repository/AnsibleTaskRepo.ts
@@ -9,7 +9,7 @@ async function create(ansibleTask: AnsibleTask): Promise<AnsibleTask> {
 }
 
 async function updateStatus(ident: string, status: string) {
-  return await AnsibleTaskModel.findOneAndUpdate({ ident: { $eq: ident } }, { status: status })
+  return await AnsibleTaskModel.findOneAndUpdate({ ident: { $eq: ident } }, { status: { $eq: status } })
     .lean()
     .exec();
 }


### PR DESCRIPTION
Potential fix for [https://github.com/SquirrelCorporation/SquirrelServersManager/security/code-scanning/45](https://github.com/SquirrelCorporation/SquirrelServersManager/security/code-scanning/45)

To fix the problem, we need to ensure that the user-provided `status` parameter is safely embedded into the MongoDB query. We can achieve this by using the `$eq` operator to ensure that the `status` is interpreted as a literal value and not as a query object. This will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
