### PR TITLE
fix(proxy): change to `error_log /dev/null`

### DIFF
--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -2,7 +2,7 @@ server {
   listen 8000;
   server_name localhost;
   access_log off;
-  error_log off;
+  error_log /dev/null;
  
   location /api/socket.io/ {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Hi,
I am creating a ansible-role to add SSM to the [MASH-Playbook](https://github.com/mother-of-all-self-hosting/mash-playbook). 
The role should run the container in read-only mode. It is necessary to change `error_log off` to `error_log /dev/null` to prevent nginx from trying to create the file `/etc/nginx/off` (See: https://ahmetkun.com/post/etc-nginx-off-what-might-that-be/).

I'm looking forward to finally use SSM and share the role with you, after I finished it.

