### PR TITLE
[CHORE] Add last updated timestamps to system information tabs

### DIFF
--- a/client/src/components/DeviceComponents/DeviceInformation/components/CPUTab.tsx
+++ b/client/src/components/DeviceComponents/DeviceInformation/components/CPUTab.tsx
@@ -125,6 +125,7 @@ const CPUTab: React.FC<CPUTabProps> = ({ device }) => {
       name={'CPU'}
       importantInfo={importantInfo}
       detailedInfo={detailedInfo}
+      lastUpdatedAt={device.systemInformation.cpu?.lastUpdatedAt}
     />
   );
 };

--- a/client/src/components/DeviceComponents/DeviceInformation/components/FilesystemsTab.tsx
+++ b/client/src/components/DeviceComponents/DeviceInformation/components/FilesystemsTab.tsx
@@ -122,6 +122,9 @@ const FilesystemsTab: React.FC<FilesystemsTabProps> = ({ device }) => {
           value: index,
         };
       })}
+      lastUpdatedAt={
+        device.systemInformation.fileSystems?.[selectedInterface]?.lastUpdatedAt
+      }
     />
   );
 };

--- a/client/src/components/DeviceComponents/DeviceInformation/components/GraphicsTab.tsx
+++ b/client/src/components/DeviceComponents/DeviceInformation/components/GraphicsTab.tsx
@@ -122,6 +122,7 @@ const GraphicsTab: React.FC<USBTabProps> = ({ device }) => {
           value: index,
         }),
       )}
+      lastUpdatedAt={device.systemInformation.graphics?.lastUpdatedAt}
     />
   );
 };

--- a/client/src/components/DeviceComponents/DeviceInformation/components/MemoryTab.tsx
+++ b/client/src/components/DeviceComponents/DeviceInformation/components/MemoryTab.tsx
@@ -36,6 +36,7 @@ const MemoryTab: React.FC<MemoryTabProps> = ({ device }) => {
       name={'Memory'}
       importantInfo={importantInfo}
       detailedInfo={detailedInfo}
+      lastUpdatedAt={device.systemInformation.mem?.lastUpdatedAt}
     />
   );
 };

--- a/client/src/components/DeviceComponents/DeviceInformation/components/NetworkInterfacesTab.tsx
+++ b/client/src/components/DeviceComponents/DeviceInformation/components/NetworkInterfacesTab.tsx
@@ -169,6 +169,10 @@ const NetworkInterfacesTab: React.FC<NetworkInterfacesTabProps> = ({
           value: index,
         };
       })}
+      lastUpdatedAt={
+        device.systemInformation.networkInterfaces?.[selectedInterface]
+          ?.lastUpdatedAt
+      }
     />
   );
 };

--- a/client/src/components/DeviceComponents/DeviceInformation/components/OSTab.tsx
+++ b/client/src/components/DeviceComponents/DeviceInformation/components/OSTab.tsx
@@ -108,9 +108,10 @@ const OSTab: React.FC<OSTabProps> = ({ device }) => {
   }));
   return (
     <SystemInformationView
-      name={'Operating System'}
+      name={'OS'}
       importantInfo={importantInfo}
       detailedInfo={detailedInfo}
+      lastUpdatedAt={device.systemInformation.os?.lastUpdatedAt}
     />
   );
 };

--- a/client/src/components/DeviceComponents/DeviceInformation/components/SystemInformationView.tsx
+++ b/client/src/components/DeviceComponents/DeviceInformation/components/SystemInformationView.tsx
@@ -1,7 +1,8 @@
 import { ProFormSelect } from '@ant-design/pro-components';
-import { Avatar, Card, Col, List, Row, Typography } from 'antd';
+import { Avatar, Card, Col, List, Row, Typography, Tooltip } from 'antd';
 import { motion } from 'framer-motion';
 import React from 'react';
+import { ClockCircleOutlined } from '@ant-design/icons';
 
 export type ImportantInfo = {
   icon: React.ReactNode;
@@ -27,6 +28,7 @@ export type SystemInformationViewProps = {
   }[];
   selectedInterface?: number;
   setSelectedInterface?: (value: any) => void;
+  lastUpdatedAt?: string;
 };
 const SystemInformationView: React.FC<SystemInformationViewProps> = ({
   importantInfo,
@@ -35,6 +37,7 @@ const SystemInformationView: React.FC<SystemInformationViewProps> = ({
   setSelectedInterface,
   selectedInterface,
   name,
+  lastUpdatedAt,
 }) => {
   // Framer Motion Variants for Animations
   const listItemVariants = {
@@ -57,8 +60,20 @@ const SystemInformationView: React.FC<SystemInformationViewProps> = ({
         borderRadius: '8px',
         paddingTop: '8px',
         paddingBottom: '8px',
+        position: 'relative',
       }}
     >
+      {/* Top right update icon */}
+      {lastUpdatedAt && (
+        <div style={{ position: 'absolute', top: 8, right: 16, zIndex: 10 }}>
+          <Tooltip
+            title={`Last updated: ${new Date(lastUpdatedAt).toLocaleString()}`}
+            placement="left"
+          >
+            <ClockCircleOutlined style={{ fontSize: 18, color: '#aaa' }} />
+          </Tooltip>
+        </div>
+      )}
       {/* Left Column: Important Info */}
       <Col
         span={8}

--- a/client/src/components/DeviceComponents/DeviceInformation/components/SystemTab.tsx
+++ b/client/src/components/DeviceComponents/DeviceInformation/components/SystemTab.tsx
@@ -86,8 +86,9 @@ const SystemTab: React.FC<SystemTabProps> = ({ device }) => {
   return (
     <SystemInformationView
       name={'System'}
-      detailedInfo={detailedInfo}
       importantInfo={importantInfo}
+      detailedInfo={detailedInfo}
+      lastUpdatedAt={device.systemInformation.system?.lastUpdatedAt}
     />
   );
 };

--- a/client/src/components/DeviceComponents/DeviceInformation/components/USBTab.tsx
+++ b/client/src/components/DeviceComponents/DeviceInformation/components/USBTab.tsx
@@ -98,10 +98,15 @@ const USBTab: React.FC<USBTabProps> = ({ device }) => {
       detailedInfo={detailedInfo}
       selectedInterface={selectedInterface}
       setSelectedInterface={setSelectedInterface}
-      options={device?.systemInformation?.usb?.map((e, index) => ({
-        label: `${e.name} (${e.bus})`,
-        value: index,
-      }))}
+      options={device?.systemInformation?.usb?.map((e, index) => {
+        return {
+          label: `${e.name} (${e.manufacturer})`,
+          value: index,
+        };
+      })}
+      lastUpdatedAt={
+        device.systemInformation.usb?.[selectedInterface]?.lastUpdatedAt
+      }
     />
   );
 };

--- a/client/src/components/DeviceComponents/DeviceInformation/components/WifiTab.tsx
+++ b/client/src/components/DeviceComponents/DeviceInformation/components/WifiTab.tsx
@@ -64,17 +64,20 @@ const WifiTab: React.FC<WifiTabProps> = ({ device }) => {
 
   return (
     <SystemInformationView
-      name={'Wifi'}
+      name={'WiFi'}
       importantInfo={importantInfo}
       detailedInfo={detailedInfo}
       selectedInterface={selectedInterface}
       setSelectedInterface={setSelectedInterface}
       options={device?.systemInformation?.wifi?.map((e, index) => {
         return {
-          label: `${e.iface} (${e.id})`,
+          label: `${e.iface} (${e.model})`,
           value: index,
         };
       })}
+      lastUpdatedAt={
+        device.systemInformation.wifi?.[selectedInterface]?.lastUpdatedAt
+      }
     />
   );
 };

--- a/client/src/pages/Admin/Inventory/components/tabs/SystemInformationConfigurationTab.tsx
+++ b/client/src/pages/Admin/Inventory/components/tabs/SystemInformationConfigurationTab.tsx
@@ -23,7 +23,7 @@ import {
   ProFormSwitch,
 } from '@ant-design/pro-components';
 import message from '@/components/Message/DynamicMessage';
-import { Card, Space, Tooltip } from 'antd';
+import { Card, Divider, Space, Tag, Tooltip } from 'antd';
 import React, { useEffect } from 'react';
 import Cron from 'react-js-cron';
 import { API } from 'ssm-shared-lib';
@@ -43,6 +43,9 @@ const SystemInformationConfigurationTab: React.FC<
   );
   const [isFeatureEnabled, setIsFeatureEnabled] = React.useState<boolean>();
   const [cron, setCron] = React.useState<string>('');
+  const [lastUpdatedAt, setLastUpdatedAt] = React.useState<
+    string | undefined
+  >();
 
   useEffect(() => {
     if (device.configuration?.systemInformation) {
@@ -55,6 +58,11 @@ const SystemInformationConfigurationTab: React.FC<
         device.configuration?.systemInformation?.[
           selectedFeature as keyof typeof device.configuration.systemInformation
         ]?.cron ?? '',
+      );
+      setLastUpdatedAt(
+        device.systemInformation?.[
+          selectedFeature as keyof typeof device.systemInformation
+        ]?.lastUpdatedAt ?? undefined,
       );
     }
   }, [selectedFeature]);
@@ -181,6 +189,12 @@ const SystemInformationConfigurationTab: React.FC<
             />
           </ProForm.Item>
         </ProForm.Group>
+        <Divider>
+          Last updated at:{' '}
+          <Tag>
+            {lastUpdatedAt ? new Date(lastUpdatedAt).toLocaleString() : 'never'}
+          </Tag>
+        </Divider>
       </Card>
     </ProForm>
   );

--- a/server/src/modules/devices/domain/entities/device.entity.ts
+++ b/server/src/modules/devices/domain/entities/device.entity.ts
@@ -99,20 +99,7 @@ export interface IDevice {
   fqdn?: string;
   status: SsmStatus.DeviceStatus;
   uptime?: number;
-  systemInformation: {
-    system?: Systeminformation.SystemData;
-    os?: Systeminformation.OsData;
-    cpu?: Systeminformation.CpuData;
-    mem?: Partial<Systeminformation.MemData>;
-    networkInterfaces?: Systeminformation.NetworkInterfacesData[];
-    versions?: Systeminformation.VersionData;
-    usb?: Systeminformation.UsbData;
-    wifi?: Systeminformation.WifiInterfaceData[];
-    bluetooth?: Systeminformation.BluetoothDeviceData[];
-    graphics?: Systeminformation.GraphicsData;
-    memLayout?: Systeminformation.MemLayoutData[];
-    fileSystems?: Systeminformation.DiskLayoutData[];
-  };
+  systemInformation: Systeminformation.SystemInformation;
   ip?: string;
   agentVersion?: string;
   createdAt?: Date;

--- a/server/src/modules/remote-system-information/infrastructure/queue/remote-system-information.processor.ts
+++ b/server/src/modules/remote-system-information/infrastructure/queue/remote-system-information.processor.ts
@@ -49,42 +49,90 @@ export class RemoteSystemInformationProcessor {
       switch (updateType) {
         case UpdateType.CPU:
           device.systemInformation.cpu = data as Systeminformation.CpuData;
+          if (device.systemInformation.cpu) {
+            device.systemInformation.cpu.lastUpdatedAt = new Date().toISOString();
+          }
           break;
         case UpdateType.Memory:
           device.systemInformation.mem = data as Systeminformation.MemData;
+          if (device.systemInformation.mem) {
+            (device.systemInformation.mem as any).lastUpdatedAt = new Date().toISOString();
+          }
           break;
         case UpdateType.FileSystems:
           device.systemInformation.fileSystems = data as Systeminformation.DiskLayoutData[];
+          if (Array.isArray(device.systemInformation.fileSystems)) {
+            device.systemInformation.fileSystems.forEach((fs) => {
+              fs.lastUpdatedAt = new Date().toISOString();
+            });
+          }
           break;
         case UpdateType.Network:
           device.systemInformation.networkInterfaces =
             data as Systeminformation.NetworkInterfacesData[];
+          if (Array.isArray(device.systemInformation.networkInterfaces)) {
+            device.systemInformation.networkInterfaces.forEach((ni) => {
+              ni.lastUpdatedAt = new Date().toISOString();
+            });
+          }
           break;
         case UpdateType.Graphics:
           device.systemInformation.graphics = data as Systeminformation.GraphicsData;
+          if (device.systemInformation.graphics) {
+            device.systemInformation.graphics.lastUpdatedAt = new Date().toISOString();
+          }
           break;
         case UpdateType.WiFi:
           device.systemInformation.wifi = data as Systeminformation.WifiInterfaceData[];
+          if (Array.isArray(device.systemInformation.wifi)) {
+            device.systemInformation.wifi.forEach((w) => {
+              w.lastUpdatedAt = new Date().toISOString();
+            });
+          }
           break;
         case UpdateType.USB:
-          device.systemInformation.usb = data as Systeminformation.UsbData;
+          device.systemInformation.usb = data as Systeminformation.UsbData[];
+          if (Array.isArray(device.systemInformation.usb)) {
+            device.systemInformation.usb.forEach((u) => {
+              u.lastUpdatedAt = new Date().toISOString();
+            });
+          }
           break;
         case UpdateType.OS:
           device.systemInformation.os = data as Systeminformation.OsData;
+          if (device.systemInformation.os) {
+            device.systemInformation.os.lastUpdatedAt = new Date().toISOString();
+          }
           device.fqdn = (data as Systeminformation.OsData)?.fqdn;
           device.hostname = (data as Systeminformation.OsData)?.hostname;
           break;
         case UpdateType.System:
           device.systemInformation.system = data as Systeminformation.SystemData;
+          if (device.systemInformation.system) {
+            device.systemInformation.system.lastUpdatedAt = new Date().toISOString();
+          }
           break;
         case UpdateType.Versions:
           device.systemInformation.versions = data as Systeminformation.VersionData;
+          if (device.systemInformation.versions) {
+            device.systemInformation.versions.lastUpdatedAt = new Date().toISOString();
+          }
           break;
         case UpdateType.MemoryLayout:
           device.systemInformation.memLayout = data as Systeminformation.MemLayoutData[];
+          if (Array.isArray(device.systemInformation.memLayout)) {
+            device.systemInformation.memLayout.forEach((m) => {
+              m.lastUpdatedAt = new Date().toISOString();
+            });
+          }
           break;
         case UpdateType.Bluetooth:
           device.systemInformation.bluetooth = data as Systeminformation.BluetoothDeviceData[];
+          if (Array.isArray(device.systemInformation.bluetooth)) {
+            device.systemInformation.bluetooth.forEach((b) => {
+              b.lastUpdatedAt = new Date().toISOString();
+            });
+          }
           break;
         case UpdateStatsType.CPU_STATS:
           await this.processCpuStatistics(data, deviceUuid);

--- a/shared-lib/src/namespace/system-information.ts
+++ b/shared-lib/src/namespace/system-information.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/sebhildebrandt/systeminformation
 // Definitions by: sebhildebrandt <https://github.com/sebhildebrandt>
 
-
 export namespace Systeminformation {
   // 1. General
 
@@ -32,6 +31,7 @@ export namespace Systeminformation {
     virtualHost?: string;
     raspberry?: RaspberryRevisionData;
     type?: string;
+    lastUpdatedAt?: string;
   }
 
   export interface BiosData {
@@ -44,7 +44,7 @@ export namespace Systeminformation {
     features?: string[];
   }
 
-  export  interface BaseboardData {
+  export interface BaseboardData {
     manufacturer: string;
     model: string;
     version: string;
@@ -66,7 +66,7 @@ export namespace Systeminformation {
 
   // 3. CPU, Memory, Disks, Battery, Graphics
 
-  export  interface CpuData {
+  export interface CpuData {
     manufacturer: string;
     brand: string;
     vendor: string;
@@ -88,9 +88,10 @@ export namespace Systeminformation {
     flags: string;
     virtualization: boolean;
     cache: CpuCacheData;
+    lastUpdatedAt?: string;
   }
 
-  export  interface CpuCacheData {
+  export interface CpuCacheData {
     l1d: number | string | null;
     l1i: number | string | null;
     l2: number | string | null;
@@ -98,14 +99,14 @@ export namespace Systeminformation {
     cache?: any;
   }
 
-  export  interface CpuCurrentSpeedData {
+  export interface CpuCurrentSpeedData {
     min: number;
     max: number;
     avg: number;
     cores: number[];
   }
 
-  export  interface CpuTemperatureData {
+  export interface CpuTemperatureData {
     main: number | null;
     cores: number[];
     max: number | null;
@@ -113,7 +114,7 @@ export namespace Systeminformation {
     chipset?: number | null;
   }
 
-  export  interface MemData {
+  export interface MemData {
     total: number;
     free: number;
     used: number;
@@ -128,6 +129,7 @@ export namespace Systeminformation {
     swapfree: number;
     writeback: number | null;
     dirty: number | null;
+    lastUpdatedAt?: string;
   }
 
   export interface MemLayoutData {
@@ -143,6 +145,7 @@ export namespace Systeminformation {
     voltageConfigured: number | null;
     voltageMin: number | null;
     voltageMax: number | null;
+    lastUpdatedAt?: string;
   }
 
   export interface SmartData {
@@ -259,7 +262,7 @@ export namespace Systeminformation {
     };
   }
 
-  export  interface DiskLayoutData {
+  export interface DiskLayoutData {
     device: string;
     type: string;
     name: string;
@@ -279,6 +282,7 @@ export namespace Systeminformation {
     temperature: null | number;
     smartData?: SmartData;
     BSDName?: string;
+    lastUpdatedAt?: string;
   }
 
   export interface BatteryData {
@@ -300,12 +304,13 @@ export namespace Systeminformation {
     additionalBatteries?: BatteryData[];
   }
 
-  export  interface GraphicsData {
+  export interface GraphicsData {
     controllers: GraphicsControllerData[];
     displays: GraphicsDisplayData[];
+    lastUpdatedAt?: string;
   }
 
-  export  interface GraphicsControllerData {
+  export interface GraphicsControllerData {
     vendor: string;
     subVendor?: string;
     vendorId?: string;
@@ -362,7 +367,7 @@ export namespace Systeminformation {
 
   // 4. Operating System
 
-  export  interface OsData {
+  export interface OsData {
     platform: string;
     distro: string;
     release: string;
@@ -379,9 +384,10 @@ export namespace Systeminformation {
     uefi: boolean | null;
     hypervizor?: boolean;
     remoteSession?: boolean;
+    lastUpdatedAt?: string;
   }
 
-  export  interface UuidData {
+  export interface UuidData {
     os: string;
     hardware: string;
     macs: string[];
@@ -425,6 +431,7 @@ export namespace Systeminformation {
     fish?: string;
     bun?: string;
     deno?: string;
+    lastUpdatedAt?: string;
   }
 
   export interface UserData {
@@ -456,7 +463,7 @@ export namespace Systeminformation {
     available: number | null;
   }
 
-  export  interface BlockDevicesData {
+  export interface BlockDevicesData {
     name: string;
     identifier: string;
     type: string;
@@ -530,9 +537,10 @@ export namespace Systeminformation {
     netEnabled?: boolean;
     vendor?: string;
     model?: string;
+    lastUpdatedAt?: string;
   }
 
-  export  interface NetworkStatsData {
+  export interface NetworkStatsData {
     iface: string;
     operstate: string;
     rx_bytes: number;
@@ -578,12 +586,13 @@ export namespace Systeminformation {
     rsnFlags: string[];
   }
 
-  export  interface WifiInterfaceData {
+  export interface WifiInterfaceData {
     id: string;
     iface: string;
     model: string;
     vendor: string;
     mac: string;
+    lastUpdatedAt?: string;
   }
 
   export interface WifiConnectionData {
@@ -624,7 +633,7 @@ export namespace Systeminformation {
     cpus: CurrentLoadCpuData[];
   }
 
-  export  interface CurrentLoadCpuData {
+  export interface CurrentLoadCpuData {
     load: number;
     loadUser: number;
     loadSystem: number;
@@ -643,7 +652,7 @@ export namespace Systeminformation {
     rawLoadGuest: number;
   }
 
-  export  interface ProcessesData {
+  export interface ProcessesData {
     all: number;
     running: number;
     blocked: number;
@@ -652,7 +661,7 @@ export namespace Systeminformation {
     list: ProcessesProcessData[];
   }
 
-  export  interface ProcessesProcessData {
+  export interface ProcessesProcessData {
     pid: number;
     parentPid: number;
     name: string;
@@ -673,7 +682,7 @@ export namespace Systeminformation {
     path: string;
   }
 
-  export  interface ProcessesProcessLoadData {
+  export interface ProcessesProcessLoadData {
     proc: string;
     pid: number;
     pids: number[];
@@ -681,7 +690,7 @@ export namespace Systeminformation {
     mem: number;
   }
 
-  export  interface ServicesData {
+  export interface ServicesData {
     name: string;
     running: boolean;
     startmode: string;
@@ -762,7 +771,7 @@ export namespace Systeminformation {
     rootFS: any;
   }
 
-  export  interface DockerContainerData {
+  export interface DockerContainerData {
     id: string;
     name: string;
     image: string;
@@ -782,7 +791,7 @@ export namespace Systeminformation {
     mounts: DockerContainerMountData[];
   }
 
-  export  interface DockerContainerMountData {
+  export interface DockerContainerMountData {
     Type: string;
     Source: string;
     Destination: string;
@@ -791,7 +800,7 @@ export namespace Systeminformation {
     Propagation: string;
   }
 
-  export  interface DockerContainerStatsData {
+  export interface DockerContainerStatsData {
     id: string;
     memUsage: number;
     memLimit: number;
@@ -830,7 +839,7 @@ export namespace Systeminformation {
     command: string;
   }
 
-  export  interface DockerVolumeData {
+  export interface DockerVolumeData {
     name: string;
     driver: string;
     labels: any;
@@ -842,7 +851,7 @@ export namespace Systeminformation {
 
   // 9. Virtual Box
 
-  export  interface VboxInfoData {
+  export interface VboxInfoData {
     id: string;
     name: string;
     running: boolean;
@@ -881,7 +890,7 @@ export namespace Systeminformation {
     rtc: string;
   }
 
-  export  interface PrinterData {
+  export interface PrinterData {
     id: number;
     name: string;
     model: string;
@@ -904,6 +913,7 @@ export namespace Systeminformation {
     manufacturer: string;
     maxPower: string | null;
     serialNumber: string | number | null;
+    lastUpdatedAt?: string;
   }
 
   export interface AudioData {
@@ -920,7 +930,7 @@ export namespace Systeminformation {
     status: string;
   }
 
-  export  interface BluetoothDeviceData {
+  export interface BluetoothDeviceData {
     device: string | null;
     name: string | null;
     macDevice: string | null;
@@ -929,6 +939,7 @@ export namespace Systeminformation {
     manufacturer: string | null;
     type: string;
     connected: boolean | null;
+    lastUpdatedAt?: string;
   }
 
   // 10. "Get All at once" - functions
@@ -968,5 +979,33 @@ export namespace Systeminformation {
     disksIO: DisksIoData;
     wifiNetworks: WifiNetworkData;
     inetLatency: number;
+  }
+
+  export interface SystemInformation {
+    cpu?: CpuData;
+    cpuUpdatedAt?: string;
+    mem?: Partial<MemData>;
+    memUpdatedAt?: string;
+    fileSystems?: DiskLayoutData[];
+    fileSystemsUpdatedAt?: string;
+    networkInterfaces?: NetworkInterfacesData[];
+    networkInterfacesUpdatedAt?: string;
+    graphics?: GraphicsData;
+    graphicsUpdatedAt?: string;
+    wifi?: WifiInterfaceData[];
+    wifiUpdatedAt?: string;
+    usb?: UsbData[];
+    usbUpdatedAt?: string;
+    os?: OsData;
+    osUpdatedAt?: string;
+    system?: SystemData;
+    systemUpdatedAt?: string;
+    versions?: VersionData;
+    versionsUpdatedAt?: string;
+    memLayout?: MemLayoutData[];
+    memLayoutUpdatedAt?: string;
+    bluetooth?: BluetoothDeviceData[];
+    bluetoothUpdatedAt?: string;
+    // ...other fields as before
   }
 }

--- a/shared-lib/src/types/api.ts
+++ b/shared-lib/src/types/api.ts
@@ -276,6 +276,7 @@ export type DeviceSystemInformation = {
   bluetooth?: Systeminformation.BluetoothDeviceData[];
   graphics?: Systeminformation.GraphicsData;
   fileSystems?: Systeminformation.DiskLayoutData[];
+  memLayout?: Systeminformation.MemLayoutData[];
 };
 
 export type DeviceItem = {


### PR DESCRIPTION
- Included `lastUpdatedAt` prop in CPUTab, FilesystemsTab, GraphicsTab, MemoryTab, NetworkInterfacesTab, OSTab, SystemTab, USBTab, and WifiTab components to display the last update time for each system information section.
- Updated SystemInformationView to render a tooltip with the last updated timestamp.
- Enhanced the device entity and system information types to support last updated timestamps for various components.