### PR TITLE
[CHORE] Add support for CPU, Memory, and File System stats monitoring.

### DIFF
--- a/client/src/components/Terminal/RemoteSystemInformationTerminal.tsx
+++ b/client/src/components/Terminal/RemoteSystemInformationTerminal.tsx
@@ -298,6 +298,9 @@ const RemoteSystemInformationTerminal: React.FC<
     { label: 'Bluetooth', value: 'bluetooth' },
     { label: 'Network Interfaces', value: 'networkinterfaces' },
     { label: 'Versions', value: 'versions' },
+    { label: 'CPU Stats', value: 'cpuStats' },
+    { label: 'Memory Stats', value: 'memStats' },
+    { label: 'File System Stats', value: 'fileSystemStats' },
   ];
 
   return (

--- a/server/src/modules/remote-system-information/application/services/components/watchers/remote-system-information-watcher.ts
+++ b/server/src/modules/remote-system-information/application/services/components/watchers/remote-system-information-watcher.ts
@@ -583,6 +583,15 @@ export class RemoteSystemInformationWatcher extends SSHExecutor {
           case 'versions':
             await this.getVersions(debugCallback);
             break;
+          case 'cpustats':
+            await this.getCpuStats(debugCallback);
+            break;
+          case 'memstats':
+            await this.getMemoryStats(debugCallback);
+            break;
+          case 'filesystemstats':
+            await this.getFileSystemStats(debugCallback);
+            break;
           default:
             throw new Error(`Component ${componentName} not supported for debug execution`);
         }


### PR DESCRIPTION
Extended the watcher to handle `cpustats`, `memstats`, and `filesystemstats` components. Updated the terminal UI to include options for monitoring these new stats. This enhances system debugging and provides more comprehensive system monitoring capabilities.