### PR TITLE
[BUG] Fix potential null coalescing issue in FilesystemsTab

### DIFF
--- a/client/src/components/DeviceComponents/DeviceInformation/components/FilesystemsTab.tsx
+++ b/client/src/components/DeviceComponents/DeviceInformation/components/FilesystemsTab.tsx
@@ -123,7 +123,8 @@ const FilesystemsTab: React.FC<FilesystemsTabProps> = ({ device }) => {
         };
       })}
       lastUpdatedAt={
-        device.systemInformation.fileSystems?.[selectedInterface]?.lastUpdatedAt
+        device.systemInformation.fileSystems?.[selectedInterface ?? 0]
+          ?.lastUpdatedAt
       }
     />
   );


### PR DESCRIPTION
Adjusted the logic for accessing `lastUpdatedAt` to use a fallback index of 0 when `selectedInterface` is undefined. This ensures safer handling of optional chaining and prevents possible runtime errors.