### PR TITLE
[BUG] Set cookie 'secure' flag to false

### DIFF
--- a/server/src/modules/users/presentation/controllers/users.controller.ts
+++ b/server/src/modules/users/presentation/controllers/users.controller.ts
@@ -86,7 +86,7 @@ export class UsersController {
 
     response.cookie('jwt', token, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
+      secure: false,
     });
     this.eventEmitter.emit(Events.TELEMETRY_EVENT, {
       eventName: 'user login',


### PR DESCRIPTION
Since there is no https support out of the box, putting back the option for the cookie for HTTP support