### PR TITLE
Fix device.systemInformation stats update logic in processor

### DIFF
--- a/client/src/pages/Admin/Inventory/components/tabs/SystemInformationConfigurationTab.tsx
+++ b/client/src/pages/Admin/Inventory/components/tabs/SystemInformationConfigurationTab.tsx
@@ -68,6 +68,7 @@ const SystemInformationConfigurationTab: React.FC<
         device.systemInformation?.[
           selectedFeature as keyof typeof device.systemInformation
         ];
+
       let updatedAt: string | undefined = undefined;
       if (Array.isArray(info)) {
         const firstWithLastUpdated = info.find(

--- a/server/src/modules/remote-system-information/infrastructure/queue/remote-system-information.processor.ts
+++ b/server/src/modules/remote-system-information/infrastructure/queue/remote-system-information.processor.ts
@@ -140,6 +140,8 @@ export class RemoteSystemInformationProcessor {
             device.systemInformation.cpuStats = {
               lastUpdatedAt: new Date().toISOString(),
             };
+          } else {
+            device.systemInformation.cpuStats.lastUpdatedAt = new Date().toISOString();
           }
           break;
         case UpdateStatsType.MEM_STATS:
@@ -148,6 +150,8 @@ export class RemoteSystemInformationProcessor {
             device.systemInformation.memStats = {
               lastUpdatedAt: new Date().toISOString(),
             };
+          } else {
+            device.systemInformation.memStats.lastUpdatedAt = new Date().toISOString();
           }
           break;
         case UpdateStatsType.FILE_SYSTEM_STATS:
@@ -156,16 +160,15 @@ export class RemoteSystemInformationProcessor {
             device.systemInformation.fileSystemsStats = {
               lastUpdatedAt: new Date().toISOString(),
             };
+          } else {
+            device.systemInformation.fileSystemsStats.lastUpdatedAt = new Date().toISOString();
           }
           break;
         default:
           throw new Error(`Unknown update type: ${updateType}`);
       }
 
-      if (!Object.values(UpdateStatsType).includes(updateType as UpdateStatsType)) {
-        // Save the updated device back to the database for non-stats updates
-        await this.devicesService.update(device);
-      }
+      await this.devicesService.update(device);
 
       this.logger.log(`Successfully updated ${updateType} for device ${deviceUuid} (${device.ip})`);
     } catch (error: any) {


### PR DESCRIPTION
- Correctly update `lastUpdatedAt` timestamps for CPU, memory, and file system stats.
- Ensure `devicesService.update` is consistently called to persist changes.