### PR TITLE
[CHORE] Add storage path flag to Prometheus entrypoint script

### DIFF
--- a/prometheus/entrypoint.sh
+++ b/prometheus/entrypoint.sh
@@ -23,4 +23,4 @@ else
 fi
 
 # Start Prometheus
-exec su -s /bin/sh nobody -c "/bin/prometheus --config.file=\"$DYNAMIC_CONFIG\""
+exec su -s /bin/sh nobody -c "/bin/prometheus --config.file=\"$DYNAMIC_CONFIG\" --storage.tsdb.path=/prometheus"


### PR DESCRIPTION
- Updated `entrypoint.sh` to include `--storage.tsdb.path` flag for Prometheus, setting the storage path to `/prometheus`.